### PR TITLE
Fix YSCB APP tag location

### DIFF
--- a/Boundaries/YSCB/CB.json
+++ b/Boundaries/YSCB/CB.json
@@ -6,8 +6,8 @@
       "CB"
     ],
     "name": "Canberra Approach East",
-    "label_lat": -35.306946,
-    "label_lon": 149.195
+    "label_lat": -35.000000,
+    "label_lon": 148.9019456
   },
   "geometry": {
     "type": "MultiPolygon",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
move YSCB tag to the left to fix an [issue](https://github.com/vatsimnetwork/simaware-tracon-project/issues/401)

## Motivation and Context
fixes tag for vatsim radars display of YSCB
Closes #401

## How to prove the effect of this PR?
lat long slight change 

## Additional info
![image](https://github.com/user-attachments/assets/33456a55-aacb-4cea-a63d-94c3cbd1b70d)

## Is this a breaking change?
no

## Checklist

- [x] My change or addition follow the formatting standard of the project.
- [ ] I am on the list of approved contributors. 

<!-- markdownlint-disable-file MD041 -->
