### PR TITLE
Fix YKM boundaries to match previous PRs

### DIFF
--- a/Boundaries/YKM/YKM.json
+++ b/Boundaries/YKM/YKM.json
@@ -5,7 +5,9 @@
     "prefix": [
       "YKM"
     ],
-    "name": "Spokane Approach"
+    "name": "Spokane Approach",
+    "label_lat": 46.94172,
+    "label_lon": -120.91115
   },
   "geometry": {
     "type": "MultiPolygon",


### PR DESCRIPTION
Updated YKM boundaries to match previous PRs (PSC/GEG)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensures YKM boundaries match PSC/GEG
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here using the syntax: 'Closes #123' -->
ensures lines line up
## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- You should include one or more screenshot(s) of your change that show the changes you are implementing -->
<!--- If you are implementing changes for multiple TMAs, each TMA should have a screenshot. -->
<!--- Additionally for multiple TMAs there should be an overview screenshots that include all changes -->
<!--- You should also ensure to include a screenshot of what the changes should look like, for example from an AIP or SOP -->
![image](https://github.com/user-attachments/assets/fdede213-5bbb-40ac-bc81-aa4baa88dcc9)
(if all 3 sectors are on)
## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Is this a breaking change?
<!--- Does the change require the user to change something on their side? -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- To be on the approved list of contributors, read the README.md -->

- [x] My change or addition follow the formatting standard of the project.
- [x] I am on the list of approved contributors. 

<!-- markdownlint-disable-file MD041 -->
