### PR TITLE
Implement schema/geo validation, new helper scripts, iterate on CI pipelines, and update documentation.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,9 +30,9 @@
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
-- [ ] I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and I am on the approved-contributor list (or an approved contributor has commented their approval on this PR)
+- [ ] I have read [CONTRIBUTING.md](../../blob/main/CONTRIBUTING.md) and I am on the approved-contributor list (or an approved contributor has commented their approval on this PR)
+- [ ] My geometry meets the standards in [CONTRIBUTING.md](../../blob/main/CONTRIBUTING.md)
 - [ ] I ran `yarn validate` locally and it passes
-- [ ] My geometry meets the standards in CONTRIBUTING.md
 - [ ] If I touched a legacy file, I ran `yarn validate-geometry --fix` and brought it up to current standards
 
 <!-- markdownlint-disable-file MD041 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,38 @@
 <!--- Provide a general summary of your changes in the Title above -->
+<!-- Is this your first contribution? Read CONTRIBUTING.md before opening this PR - it covers the approval process, geometry standards, and the local validation workflow -->
 
 ## Description
-<!--- Describe your changes in detail -->
+
+<!--- Describe your changes in detail. Which facility/facilities? Which sectors? -->
 
 ## Motivation and Context
+
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here using the syntax: 'Closes #123' -->
 
-## How to prove the effect of this PR?
-<!--- Please describe in detail how verify the change you have done. -->
-<!--- You should include one or more screenshot(s) of your change that show the changes you are implementing -->
-<!--- If you are implementing changes for multiple TMAs, each TMA should have a screenshot. -->
-<!--- Additionally for multiple TMAs there should be an overview screenshots that include all changes -->
-<!--- You should also ensure to include a screenshot of what the changes should look like, for example from an AIP or SOP -->
+## Verification
+
+<!-- How can a reviewer confirm this change is correct? -->
+<!-- Include one or more screenshots of the new geometry rendered in a GIS viewer (e.g. https://geojson.io) -->
+<!-- If you are changing multiple sectors, include a per-sector screenshot AND an overview screenshot -->
+<!-- Include a screenshot or excerpt of the authoritative source (AIP, SOP, official chart) showing what the geometry should look like -->
+
+## Supporting documentation
+
+<!-- For new sectors, attach or link the AIP excerpts, SOPs, or charts you used. Required for new sectors; helpful for any non-trivial change -->
 
 ## Additional info
-<!--- Ignore if not relevant -->
-<!--- For example screenshots -->
 
-## Is this a breaking change?
-<!--- Does the change require the user to change something on their side? -->
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+<!-- Anything else reviewers should know. Ignore if not relevant -->
 
 ## Checklist
+
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-<!--- To be on the approved list of contributors, read the README.md -->
 
-- [ ] My change or addition follow the formatting standard of the project.
-- [ ] I am on the list of approved contributors. 
+- [ ] I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and I am on the approved-contributor list (or an approved contributor has commented their approval on this PR)
+- [ ] I ran `yarn validate` locally and it passes
+- [ ] My geometry meets the standards in CONTRIBUTING.md
+- [ ] If I touched a legacy file, I ran `yarn validate-geometry --fix` and brought it up to current standards
 
 <!-- markdownlint-disable-file MD041 -->

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -150,4 +150,4 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
-          printf '%s\n' "$CHANGED_FILES" | yarn --silent validate-geometry --changed-only
+          printf '%s\n' "$CHANGED_FILES" | yarn validate-geometry --changed-only

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,26 @@ jobs:
         shell: sh
         working-directory: ./scripts
         run: yarn validate-schema
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Install deps
+        shell: sh
+        working-directory: ./scripts
+        run: yarn
+      - name: ESLint
+        shell: sh
+        working-directory: ./scripts
+        run: yarn lint
+      - name: Prettier (check)
+        shell: sh
+        working-directory: ./scripts
+        run: yarn format:check
   validate-contributor:
     runs-on: ubuntu-latest
     steps:
@@ -36,8 +56,7 @@ jobs:
       - name: Check Boundaries.geojson
         shell: sh
         working-directory: ./scripts
-        run: yarn check-contributor --login="${{ github.event.pull_request.user.login
-          }}" --failWhenMissing
+        run: yarn check-contributor --login="${{ github.event.pull_request.user.login }}" --failWhenMissing
   compile-boundaries:
     runs-on: ubuntu-latest
     steps:
@@ -57,9 +76,11 @@ jobs:
       - name: Upload compile artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: TRACONBoundaries.geojson
+          name: TRACONBoundaries-pr-${{ github.event.pull_request.number || github.run_id }}
           path: |
             TRACONBoundaries.geojson
+          if-no-files-found: error
+          retention-days: 30
   enforce-dir-structure:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Check Boundaries.geojson
         shell: sh
         working-directory: ./scripts
-        run: yarn check-contributor --login="${{ github.event.pull_request.user.login }}" --failWhenMissing
+        run: yarn check-contributor --login="${{ github.event.pull_request.user.login
+          }}" --failWhenMissing
   compile-boundaries:
     runs-on: ubuntu-latest
     steps:
@@ -87,3 +88,45 @@ jobs:
             fi
           done
           echo "Directory structure is valid."
+  validate-geometry-changed:
+    # Enforces RFC 7946 + project geometry rules on files modified in this PR
+    # only. Legacy violations on main are intentionally not blocked here; see
+    # CONTRIBUTING.md and push.yml.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Install deps
+        shell: sh
+        working-directory: ./scripts
+        run: yarn
+      - name: List changed boundary files
+        id: changed
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          CHANGED=$(git diff --name-only --diff-filter=AM "origin/$BASE_REF"...HEAD -- 'Boundaries/**/*.json' || true)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ -z "$CHANGED" ]; then
+            echo "No boundary files changed in this PR."
+          else
+            echo "Changed boundary files:"
+            echo "$CHANGED"
+          fi
+      - name: Validate geometry on changed files
+        if: steps.changed.outputs.files != ''
+        shell: bash
+        working-directory: ./scripts
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          printf '%s\n' "$CHANGED_FILES" | yarn --silent validate-geometry --changed-only

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Data check
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   check-geojson:
@@ -43,3 +43,36 @@ jobs:
           name: TRACONBoundaries.geojson
           path: |
             TRACONBoundaries.geojson
+          if-no-files-found: error
+          retention-days: 30
+  validate-geometry-full:
+    # Non-blocking full-dataset geometry sweep on main. Surfaces legacy
+    # violations as a downloadable report without failing the workflow.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Install deps
+        shell: sh
+        working-directory: ./scripts
+        run: yarn
+      - name: Run full geometry validation
+        shell: bash
+        working-directory: ./scripts
+        run: |
+          set +e
+          yarn --silent validate-geometry > ../geometry-report.txt 2>&1
+          status=$?
+          echo "validate-geometry exit code: $status" >> ../geometry-report.txt
+          exit 0
+      - name: Upload geometry report
+        uses: actions/upload-artifact@v4
+        with:
+          name: geometry-report
+          path: geometry-report.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: ./scripts
         run: |
           set +e
-          yarn --silent validate-geometry > ../geometry-report.txt 2>&1
+          yarn validate-geometry > ../geometry-report.txt 2>&1
           status=$?
           echo "validate-geometry exit code: $status" >> ../geometry-report.txt
           exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 *.bcat
 TRACONBoundaries.geojson
+OWNERSHIP_REPORT.md
 .DS_Store
+Thumbs.db
+desktop.ini
 .idea
+.vscode
+*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,20 @@ Thanks for helping keep this dataset accurate. This guide covers everything you 
 
 ## Table of contents
 
-- [Approved contributors](#approved-contributors)
-- [Submitting a pull request](#submitting-a-pull-request)
-- [Geometry standards](#geometry-standards)
-- [Local validation workflow](#local-validation-workflow)
-- [Glossary](#glossary)
+- [Contributing to the VATSIM TRACON Project](#contributing-to-the-vatsim-tracon-project)
+  - [Table of contents](#table-of-contents)
+  - [Approved contributors](#approved-contributors)
+    - [If you are a staff member](#if-you-are-a-staff-member)
+    - [If you are not a staff member](#if-you-are-not-a-staff-member)
+  - [Submitting a pull request](#submitting-a-pull-request)
+  - [Worked example](#worked-example)
+  - [Geometry standards](#geometry-standards)
+    - [Coordinate format](#coordinate-format)
+    - [Coordinate precision (error)](#coordinate-precision-error)
+    - [Polygon closure (error)](#polygon-closure-error)
+    - [Minimum positions per ring](#minimum-positions-per-ring)
+    - [Prefix/suffix uniqueness (error)](#prefixsuffix-uniqueness-error)
+  - [Local validation workflow](#local-validation-workflow)
 
 ---
 
@@ -65,6 +74,47 @@ A good example PR is [#294](https://github.com/vatsimnetwork/simaware-tracon-pro
 > **Touching a legacy file?** If your PR modifies a file that contains pre-existing geometry violations (e.g. unclosed rings, excessive coordinate precision), CI will flag those issues. You're expected to clean them up as part of your PR — by editing a file, you take ownership of bringing it up to current standards. Run `yarn validate-geometry --fix` to handle the mechanical fixes automatically.
 
 ---
+
+## Worked example
+
+A boundary file is a single GeoJSON `Feature` with a `Polygon` or `MultiPolygon` geometry. Each file lives at `Boundaries/<FACILITY>/<SECTOR>.json` - the directory is the controlling facility's identifier, the filename is the sector identifier (commonly also the airport ICAO).
+
+A minimal valid file looks like this:
+
+```json
+{
+  "type": "Feature",
+  "properties": {
+    "id": "XYZ",
+    "prefix": ["XYZ"],
+    "suffix": "APP",
+    "name": "Example Approach"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      {
+        [-100.0000000, 40.0000000],
+        [-100.0000000, 41.0000000],
+        [-99.0000000, 41.0000000],
+        [-99.0000000, 40.0000000],
+        [-100.000000, 40.0000000]
+      }
+    ]
+  }
+}
+```
+
+A few things to note about the above example:
+
+- `properties.id` is typically the label shown in the mapping tool. Keep it short.
+- `properties.prefix` is an array - a single sector definition can match multiple callsign prefixes (e.g. `["LAX", "SCT"]`).
+- `properties.suffix` is optional. If not included, mapping tools should treat it as `"APP"` for matching. The `prefix` and `suffix` pair must be unique across the entire dataset,
+- `properties.name` is the the callsign shown to controllers/pilots.
+- Coordinates are `[longitude, latitude]` in WGS84, max 7 decimal places.
+- The first and last position of every polygon must match (closure). The example's outer ring opens and closes at `[-100.0000000, 40.0000000]`.
+
+For a real-world reference, look at [`Boundaries/NZCH/NZCH.json`](Boundaries/NZCH/NZCH.json) (Christchurch Approach).
 
 ## Geometry standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ A good example PR is [#294](https://github.com/vatsimnetwork/simaware-tracon-pro
 
 ## Geometry standards
 
-These rules apply to every Polygon and MultiPolygon in the dataset. The validator (`yarn validate-geometry`) enforces the _error_-level rules; warnings are flagged but don't block merging.
+These rules apply to every Polygon and MultiPolygon in the dataset. `yarn validate-geometry` enforces them programmatically; the JSON Schema (`schema-single.json`) covers the structural rules.
 
 ### Coordinate format
 
@@ -87,22 +87,13 @@ Every linear ring **must repeat its first position as its last position** (RFC 7
 
 > **Auto-fix**: `yarn validate-geometry --fix` appends the first position to any unclosed ring.
 
-### Minimum positions per ring (error)
+### Minimum positions per ring
 
-Each linear ring needs at least **4 positions** (3 unique vertices + the closure vertex). Anything less is not a polygon.
+Each linear ring needs at least **4 positions** (3 unique vertices + the closure vertex). Anything less is not a polygon. Enforced by `schema-single.json`.
 
 ### Prefix/suffix uniqueness (error)
 
 Each `(prefix, suffix)` pair must be unique across the entire dataset. If you need finer sectorisation, use a longer prefix (e.g. `LAX_U` instead of `LAX`) — see the README for how downstream consumers typically resolves callsigns. This is checked dataset-wide, not just per-PR.
-
-### Winding order (warning, will become error)
-
-Points in a closed polygon should flow in the following directions:
-
-- **Exterior rings** are wound **counter-clockwise** (CCW).
-- **Interior rings** (holes) are wound **clockwise** (CW).
-
-The validator will trigger a warning for incorrect winding, however this will become a hard failure in a future release. Most GIS tools (QGIS, geojson.io) will set this correctly on an export.
 
 ---
 
@@ -125,6 +116,6 @@ yarn validate-geometry --fix
 yarn validate
 ```
 
-`yarn validate-geometry` exits non-zero on any error-level violation. Warnings are printed.
+`yarn validate-geometry` exits non-zero on any violation.
 
-CI runs `yarn validate-geometry --changed-only` against the files modified in your PR.
+CI runs `yarn validate-geometry --changed-only` against the files modified in your PR. The cross-file `prefix/suffix uniqueness` check considers the full dataset and only fails when a duplicate involves at least one of your changed files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,130 @@
+# Contributing to the VATSIM TRACON Project
+
+Thanks for helping keep this dataset accurate. This guide covers everything you need to know before opening a pull request: how can contribute, how to submit changes, and the geometry standards your data must meet.
+
+> **Important**: All boundary data in this project must conform to [RFC 7946 (the GeoJSON format)](https://datatracker.ietf.org/doc/html/rfc7946) and to any project-specific geometry standards in this document.
+
+## Table of contents
+
+- [Approved contributors](#approved-contributors)
+- [Submitting a pull request](#submitting-a-pull-request)
+- [Geometry standards](#geometry-standards)
+- [Local validation workflow](#local-validation-workflow)
+- [Glossary](#glossary)
+
+---
+
+## Approved contributors
+
+To contribute boundary data, you'll need approval from local or facility staff. The current list is published [here](https://docs.google.com/spreadsheets/u/4/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pubhtml?gid=0).
+
+> **Note**: The contributor database is shared with the [VAT-Spy Data Project](https://github.com/vatsimnetwork/vatspy-data-project). Approval for one project grants approval for both. If you are opening a PR and have an approval request pending, please note that in your PR.
+
+### If you are a staff member
+
+Email your request to `vatspy-data-project (at) vatsim.net`. If you're using a personal email (e.g. Gmail), include additional proof of your staff status.
+
+Include:
+
+- **GitHub username**
+- **VATSIM ID**
+- **Name**
+- **Region/FIR**
+- **Staff role**
+
+### If you are not a staff member
+
+Have a staff member from your facility email the request on your behalf. The email should include:
+
+- **Your GitHub username**
+- **Your name**
+- **Your VATSIM ID**
+- **Your Region/FIR**
+- **VATSIM ID and name of the staff member sending the request**
+
+> **Important**:
+>
+> - The **name** you provide will be published on the contributor list.
+> - Approved contributor status lasts **2 years** unless otherwise specified. After that, a fresh request is required.
+> - Approved contributors may be tagged in issues or pull requests for review.
+> - Non-approved contributors may still submit pull requests if an approved contributor comments approval on the PR. This approval is **scoped to only that PR**.
+
+---
+
+## Submitting a pull request
+
+1. Fork the repository and create a branch for your change.
+2. Make your edits inside the appropriate `Boundaries/<FACILITY>/` folder.
+3. Run the validators locally before pushing — see [Local validation workflow](#local-validation-workflow).
+4. Open a pull request using the GitHub template. Fill in every section of the template.
+5. Include one or more **screenshots** of the change in a GIS viewer (e.g. [geojson.io](https://geojson.io)) so reviewers can see what the sector looks like.
+6. For new sectors, include supporting documentation (AIP excerpts, SOPs, official charts) so reviewers can verify the geometry against an authoritative source.
+
+A good example PR is [#294](https://github.com/vatsimnetwork/simaware-tracon-project/pull/294).
+
+> **Touching a legacy file?** If your PR modifies a file that contains pre-existing geometry violations (e.g. unclosed rings, excessive coordinate precision), CI will flag those issues. You're expected to clean them up as part of your PR — by editing a file, you take ownership of bringing it up to current standards. Run `yarn validate-geometry --fix` to handle the mechanical fixes automatically.
+
+---
+
+## Geometry standards
+
+These rules apply to every Polygon and MultiPolygon in the dataset. The validator (`yarn validate-geometry`) enforces the _error_-level rules; warnings are flagged but don't block merging.
+
+### Coordinate format
+
+- Coordinates are **`[longitude, latitude]`** decimal degrees in WGS84 / CRS84.
+- Latitude must be in `[-90, 90]`; longitude in `[-180, 180]`.
+
+### Coordinate precision (error)
+
+Coordinates must use **at most 7 decimal places**. This rule is enforced **on changed files in pull requests**. The `main` branch is not re-validated for legacy data; it will be cleaned up gradually.
+
+> **Auto-fix**: `yarn validate-geometry --fix` rounds all coordinates to 7 DP in place.
+
+### Polygon closure (error)
+
+Every linear ring **must repeat its first position as its last position** (RFC 7946 §3.1.6).
+
+> **Auto-fix**: `yarn validate-geometry --fix` appends the first position to any unclosed ring.
+
+### Minimum positions per ring (error)
+
+Each linear ring needs at least **4 positions** (3 unique vertices + the closure vertex). Anything less is not a polygon.
+
+### Prefix/suffix uniqueness (error)
+
+Each `(prefix, suffix)` pair must be unique across the entire dataset. If you need finer sectorisation, use a longer prefix (e.g. `LAX_U` instead of `LAX`) — see the README for how downstream consumers typically resolves callsigns. This is checked dataset-wide, not just per-PR.
+
+### Winding order (warning, will become error)
+
+Points in a closed polygon should flow in the following directions:
+
+- **Exterior rings** are wound **counter-clockwise** (CCW).
+- **Interior rings** (holes) are wound **clockwise** (CW).
+
+The validator will trigger a warning for incorrect winding, however this will become a hard failure in a future release. Most GIS tools (QGIS, geojson.io) will set this correctly on an export.
+
+---
+
+## Local validation workflow
+
+```bash
+cd scripts
+yarn install
+
+# Schema check (type/structure)
+yarn validate-schema
+
+# Geometry check (RFC 7946 + project rules)
+yarn validate-geometry
+
+# Auto-fix safe rules (closure, precision)
+yarn validate-geometry --fix
+
+# Run both
+yarn validate
+```
+
+`yarn validate-geometry` exits non-zero on any error-level violation. Warnings are printed.
+
+CI runs `yarn validate-geometry --changed-only` against the files modified in your PR.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The SimAware TRACON Project is a community-driven initiative to have accurate TRACON (and other APP/DEP) facilities depicted on various VATSIM mapping tools. This project was originally developed exclusively for SimAware, although is open for community use.
 
-> Boundary data must conform to [RFC 7946 (The GeoJSON Format)](https://datatracker.ietf.org/doc/html/rfc7946) and the project's geometry standards. See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+> Boundary data must conform to [RFC 7946 (GeoJSON)](https://datatracker.ietf.org/doc/html/rfc7946) and the project's geometry standards. See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## Contributing
 
@@ -29,8 +29,9 @@ A typical feature property is shown:
 2. When a callsign with a matching prefix/suffix pair is found, SimAware chooses the correct TRACON boundary to draw.
 3. If no matching prefix/suffix pair is found, SimAware will revert back to a TRACON circle. Note that SimAware will assume `"suffix"="APP"` if none is specified.
 
-Note 1: If a double prefix callsign connects, e.g. LAX*U_APP, SimAware will check for matches on \_both* "LAX\*U" and "LAX" before reverting to a TRACON circle. This can be useful if further sectorization is desired, e.g. SCT Downey/Zuma sectors.  
-Note 2: If the same prefix/suffix pair is specified in the GeoJSON file, SimAware _will not_ know which one to choose. Each prefix/suffix pair _must_ be unique. This is enforced by the validator — see [CONTRIBUTING.md](CONTRIBUTING.md#prefixsuffix-uniqueness-error).
+**Note 1**: If a double prefix callsign connects, e.g. LAX_U_APP, SimAware will check for matches on both "LAX_U" and "LAX" before reverting to a TRACON circle. This can be useful if further sectorization is desired, e.g. SCT Downey/Zuma sectors.
+
+**Note 2**: If the same prefix/suffix pair is specified in the GeoJSON file, SimAware _will not_ know which one to choose. Each prefix/suffix pair _must_ be unique. This is enforced by the validator — see [CONTRIBUTING.md](CONTRIBUTING.md#prefixsuffix-uniqueness-error).
 
 ## Who's on the SimAware TRACON Project?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The SimAware TRACON Project is a community-driven initiative to have accurate TR
 
 ## Contributing
 
-Contribution requires approval from Division-level or Sub-Division-level staff. The full process — including the approved-contributor list, PR submission requirements, and the geometry standards your data must meet — lives in **[CONTRIBUTING.md](CONTRIBUTING.md)**.
+Contributions require approval from Division-level or Sub-Division-level staff. [CONTRIBUTING.md](CONTRIBUTING.md) covers the full process: the approved-contributor list, PR submission requirements, the geometry standards your data must meet, and the local validation workflow. Start there before opening a pull request.
 
 ## Feature Properties
 

--- a/README.md
+++ b/README.md
@@ -2,50 +2,11 @@
 
 The SimAware TRACON Project is a community-driven initiative to have accurate TRACON (and other APP/DEP) facilities depicted on various VATSIM mapping tools. This project was originally developed exclusively for SimAware, although is open for community use.
 
-## Approved Contributors
+> Boundary data must conform to [RFC 7946 (The GeoJSON Format)](https://datatracker.ietf.org/doc/html/rfc7946) and the project's geometry standards. See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-To contribute to this dataset, you'll need approval from a local or facility staff member. You can find a list of currently approved contributors [here](https://docs.google.com/spreadsheets/u/4/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pubhtml?gid=0).
+## Contributing
 
-> [!Note]
-> A common contributor database is shared between this project and the [VAT-Spy Data Project](https://github.com/vatsimnetwork/vatspy-data-project). If you have approval to contribute to one project, you are approved to contribute to either.
-
-### If you are a staff member
-
-Email your request to vatspy-data-project (at) vatsim.net.  
-If you're using a personal email (e.g., Gmail), we'll need additional proof of your staff status.
-
-Please include the following information in your email:
-
-- **GitHub username:**
-- **VATSIM ID:**
-- **Name:**
-- **Region/FIR:**
-- **Staff role**
- 
-### If you are not a staff member
-
-Contact the staff in your facility and have them send a request for your account to be approved.
-
-The email they send should include:
-
-- **Your GitHub username:**
-- **Your Name:**
-- **Your VATSIM ID:**
-- **Your Region/FIR:**
-- **VATSIM ID + name of staff member sending the request:**
-
-> [!IMPORTANT]
->
-> - The **Name** you provide will be published on the contributor list.
-> - Approved contributor status lasts **2 years** unless otherwise specified. After this, a new request must be sent.
-> - Contributors on the list may be tagged in issues or pull requests for their attention or input.
-> - Non-approved users can still contribute if an approved user comments on their pull request, confirming they approve the changes.
-
-### Submitting a Pull Request
-
-When submitting a Pull Request in GitHub, please make sure to use the template provided by GitHub, and fill out the information asked. This way, we can more easily identify what the change is, and how to test that it is working.
-
-You should include one or more screenshots of the change in the PR using a GIS viewer, demonstrating what the sector is supposed to look like. If this is a new change, you should also ensure that there is documentation backing up the change as necessary, for example images from an AIP that shows the sector. You can use [this example](https://github.com/vatsimnetwork/simaware-tracon-project/pull/294) to see what a PR should look like.
+Contribution requires approval from Division-level or Sub-Division-level staff. The full process — including the approved-contributor list, PR submission requirements, and the geometry standards your data must meet — lives in **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## Feature Properties
 
@@ -68,8 +29,8 @@ A typical feature property is shown:
 2. When a callsign with a matching prefix/suffix pair is found, SimAware chooses the correct TRACON boundary to draw.
 3. If no matching prefix/suffix pair is found, SimAware will revert back to a TRACON circle. Note that SimAware will assume `"suffix"="APP"` if none is specified.
 
-Note 1: If a double prefix callsign connects, e.g. LAX_U_APP, SimAware will check for matches on _both_ "LAX_U" and "LAX" before reverting to a TRACON circle. This can be useful if further sectorization is desired, e.g. SCT Downey/Zuma sectors.  
-Note 2: If the same prefix/suffix pair is specified in the GeoJSON file, SimAware _will not_ know which one to choose. Each prefix/suffix pair _must_ be unique.
+Note 1: If a double prefix callsign connects, e.g. LAX*U_APP, SimAware will check for matches on \_both* "LAX\*U" and "LAX" before reverting to a TRACON circle. This can be useful if further sectorization is desired, e.g. SCT Downey/Zuma sectors.  
+Note 2: If the same prefix/suffix pair is specified in the GeoJSON file, SimAware _will not_ know which one to choose. Each prefix/suffix pair _must_ be unique. This is enforced by the validator — see [CONTRIBUTING.md](CONTRIBUTING.md#prefixsuffix-uniqueness-error).
 
 ## Who's on the SimAware TRACON Project?
 

--- a/schema-single.json
+++ b/schema-single.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/vatsimnetwork/simaware-tracon-project/refs/heads/main/schema-single.json",
   "title": "SimAware TRACON Feature definition",
+  "$comment": "Boundaries follow RFC 7946 (https://datatracker.ietf.org/doc/html/rfc7946). Additional project-specific geometry rules (coordinate precision, ring closure, winding order, prefix/suffix uniqueness) are enforced by yarn validate-geometry. See CONTRIBUTING.md.",
   "type": "object",
   "properties": {
     "type": {
@@ -63,7 +64,7 @@
                 "minItems": 1,
                 "items": {
                   "type": "array",
-                  "minItems": 1,
+                  "minItems": 4,
                   "items": {
                     "type": "array",
                     "minItems": 2,
@@ -92,7 +93,7 @@
               "minItems": 1,
               "items": {
                 "type": "array",
-                "minItems": 1,
+                "minItems": 4,
                 "items": {
                   "type": "array",
                   "minItems": 2,

--- a/schema-single.json
+++ b/schema-single.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/vatsimnetwork/simaware-tracon-project/refs/heads/main/schema-single.json",
   "title": "SimAware TRACON Feature definition",
-  "$comment": "Boundaries follow RFC 7946 (https://datatracker.ietf.org/doc/html/rfc7946). Additional project-specific geometry rules (coordinate precision, ring closure, winding order, prefix/suffix uniqueness) are enforced by yarn validate-geometry. See CONTRIBUTING.md.",
+  "$comment": "Boundaries follow RFC 7946 (https://datatracker.ietf.org/doc/html/rfc7946). Additional project-specific geometry rules (coordinate precision, ring closure, prefix/suffix uniqueness) are enforced by yarn validate-geometry. See CONTRIBUTING.md.",
   "type": "object",
   "properties": {
     "type": {

--- a/scripts/.prettierignore
+++ b/scripts/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+.yarn/
+yarn.lock
+TRACONBoundaries.geojson
+../TRACONBoundaries.geojson
+../Boundaries/

--- a/scripts/.prettierrc.json
+++ b/scripts/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": false,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "endOfLine": "lf"
+}

--- a/scripts/bin/compile.ts
+++ b/scripts/bin/compile.ts
@@ -1,45 +1,48 @@
-import type {FeatureCollection, MultiPolygon, Polygon} from "geojson";
-import {join} from "path";
-import {lstatSync, readdirSync, readFileSync, writeFile} from "node:fs";
-import {dirname, extname} from "node:path";
-import {fileURLToPath} from "url";
+import type {FeatureCollection, MultiPolygon, Polygon} from 'geojson';
+import {join} from 'path';
+import {lstatSync, readdirSync, readFileSync, writeFile} from 'node:fs';
+import {dirname, extname} from 'node:path';
+import {fileURLToPath} from 'url';
 
 const template = {
-    type: "FeatureCollection",
-    '$schema': 'https://raw.githubusercontent.com/vatsimnetwork/simaware-tracon-project/refs/heads/main/schema.json',
-    name: "fix",
-    crs: {type: "name", properties: {name: "urn:ogc:def:crs:OGC:1.3:CRS84"}},
-    features: []
-} as FeatureCollection<MultiPolygon | Polygon>
+  type: 'FeatureCollection',
+  $schema:
+    'https://raw.githubusercontent.com/vatsimnetwork/simaware-tracon-project/refs/heads/main/schema.json',
+  name: 'fix',
+  crs: {type: 'name', properties: {name: 'urn:ogc:def:crs:OGC:1.3:CRS84'}},
+  features: [],
+} as FeatureCollection<MultiPolygon | Polygon>;
 
 const path = fileURLToPath(new URL(import.meta.url).toString());
-const rootPath = join(path, '../../../')
+const rootPath = join(path, '../../../');
 
 const files: string[] = [];
 
 function traverseDir(dir: string) {
-    readdirSync(dir).forEach(file => {
-        let fullPath = join(dir, file);
-        if (lstatSync(fullPath).isDirectory()) {
-            traverseDir(fullPath);
-        } else {
-            if (!dirname(fullPath).toLowerCase().includes("node_modules") &&
-                extname(fullPath).toLowerCase() === ".json") {
-                files.push(fullPath);
-            }
-        }
-    })
+  readdirSync(dir).forEach(file => {
+    const fullPath = join(dir, file);
+    if (lstatSync(fullPath).isDirectory()) {
+      traverseDir(fullPath);
+    } else {
+      if (
+        !dirname(fullPath).toLowerCase().includes('node_modules') &&
+        extname(fullPath).toLowerCase() === '.json'
+      ) {
+        files.push(fullPath);
+      }
+    }
+  });
 }
 
-traverseDir(join(rootPath, "Boundaries"));
+traverseDir(join(rootPath, 'Boundaries'));
 
-files.map(function (value, index) {
-    const data = readFileSync(value, 'utf8');
-    template.features.push(JSON.parse(data));
-})
+files.forEach(value => {
+  const data = readFileSync(value, 'utf8');
+  template.features.push(JSON.parse(data));
+});
 
-writeFile(join(rootPath, "/TRACONBoundaries.geojson"), JSON.stringify(template), err => {
-    if (err) {
-        console.error(err);
-    }
+writeFile(join(rootPath, '/TRACONBoundaries.geojson'), JSON.stringify(template), err => {
+  if (err) {
+    console.error(err);
+  }
 });

--- a/scripts/bin/contributor.ts
+++ b/scripts/bin/contributor.ts
@@ -1,41 +1,57 @@
-import {parseArgs} from "node:util";
-import {parse} from 'csv-parse/sync'
+import {parseArgs} from 'node:util';
+import {parse} from 'csv-parse/sync';
 
-const {values: {login, failWhenMissing}} = parseArgs({
-    args: process.argv,
-    allowPositionals: true,
-    options: {
-        login: {
-            type: 'string',
-        },
-        failWhenMissing: {
-            type: 'boolean'
-        }
+const {
+  values: {login, failWhenMissing},
+} = parseArgs({
+  args: process.argv,
+  allowPositionals: true,
+  options: {
+    login: {
+      type: 'string',
     },
+    failWhenMissing: {
+      type: 'boolean',
+    },
+  },
 });
 
-const csv = await (await fetch('https://docs.google.com/spreadsheets/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pub?gid=0&single=true&output=csv')).text()
+const csv = await (
+  await fetch(
+    'https://docs.google.com/spreadsheets/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pub?gid=0&single=true&output=csv',
+  )
+).text();
 
 const result = parse<{
-    username: string;
-    expiry: string;
-    cid: string;
-    name: string;
-    region: string;
-    role: string;
-    approvingCid: string;
-    approvingStaff: string;
+  username: string;
+  expiry: string;
+  cid: string;
+  name: string;
+  region: string;
+  role: string;
+  approvingCid: string;
+  approvingStaff: string;
 }>(csv, {
-    columns: ['username', 'expiry', 'cid', 'name', 'region', 'role', 'approvingCid', 'approvingStaff'],
-    skip_empty_lines: true,
-})
+  columns: [
+    'username',
+    'expiry',
+    'cid',
+    'name',
+    'region',
+    'role',
+    'approvingCid',
+    'approvingStaff',
+  ],
+  skip_empty_lines: true,
+});
 
 const user = result.find(x => x.username.toLowerCase() === login?.toLowerCase());
 
 if (!user) {
-    if (failWhenMissing) throw new Error(`Contributor with login ${login} was not found`)
-    else console.log('not found')
+  if (failWhenMissing) throw new Error(`Contributor with login ${login} was not found`);
+  else console.log('not found');
 } else {
-    console.log(`Contributor data:\n- CID: ${user.cid}\n- Name: ${user.name}\n- Region: ${user.region}\n- Role: ${user.role}\n- Approving CID: ${user.approvingCid}\n- Approving staff: ${user.approvingStaff}`)
+  console.log(
+    `Contributor data:\n- CID: ${user.cid}\n- Name: ${user.name}\n- Region: ${user.region}\n- Role: ${user.role}\n- Approving CID: ${user.approvingCid}\n- Approving staff: ${user.approvingStaff}`,
+  );
 }
-

--- a/scripts/bin/lib/geometry-checks.ts
+++ b/scripts/bin/lib/geometry-checks.ts
@@ -1,0 +1,186 @@
+// Geometry validation logic shared by validate-geometry.ts and
+// ownership-report.ts.
+
+import type { Feature, MultiPolygon, Polygon, Position } from "geojson";
+
+export const PRECISION_LIMIT = 7;
+
+export type Severity = "error" | "warning";
+
+export interface Violation {
+  file: string;
+  rule: string;
+  severity: Severity;
+  message: string;
+  /** Files involved when the rule is cross-file (e.g. duplicate-prefix-suffix). */
+  relatedFiles?: string[];
+}
+
+//  Geometry helpers
+
+export function eachRing(
+  feature: Feature<Polygon | MultiPolygon>,
+  cb: (ring: Position[], polygonIndex: number, ringIndex: number) => void,
+): void {
+  const geom = feature.geometry;
+  if (!geom) return;
+  if (geom.type === "Polygon") {
+    geom.coordinates.forEach((ring, ri) => cb(ring as Position[], 0, ri));
+  } else if (geom.type === "MultiPolygon") {
+    geom.coordinates.forEach((poly, pi) =>
+      poly.forEach((ring, ri) => cb(ring as Position[], pi, ri)),
+    );
+  }
+}
+
+export function decimalPlaces(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  const s = n.toString();
+  if (s.includes("e") || s.includes("E")) {
+    const [mantissa, expStr] = s.split(/[eE]/);
+    const dotIdx = mantissa.indexOf(".");
+    const mantissaDp = dotIdx === -1 ? 0 : mantissa.length - dotIdx - 1;
+    const exp = parseInt(expStr, 10);
+    return Math.max(0, mantissaDp - exp);
+  }
+  const dot = s.indexOf(".");
+  return dot === -1 ? 0 : s.length - dot - 1;
+}
+
+export function roundCoord(n: number): number {
+  const factor = 10 ** PRECISION_LIMIT;
+  return Math.round(n * factor) / factor;
+}
+
+// Per-file checks
+
+export function runFileChecks(
+  file: string,
+  feature: Feature<Polygon | MultiPolygon>,
+): Violation[] {
+  const violations: Violation[] = [];
+  const where = (pi: number, ri: number) =>
+    feature.geometry.type === "MultiPolygon"
+      ? `polygon ${pi}, ring ${ri}`
+      : `ring ${ri}`;
+
+  // Closure
+  eachRing(feature, (ring, pi, ri) => {
+    if (ring.length === 0) return;
+    const f = ring[0];
+    const l = ring[ring.length - 1];
+    if (f[0] !== l[0] || f[1] !== l[1]) {
+      violations.push({
+        file,
+        rule: "closure",
+        severity: "error",
+        message: `unclosed ring at ${where(pi, ri)}: first ${JSON.stringify(f)} != last ${JSON.stringify(l)}`,
+      });
+    }
+  });
+
+  // Precision
+  let precisionCount = 0;
+  let worstDp = 0;
+  let worstSample: Position | null = null;
+  eachRing(feature, (ring) => {
+    for (const pos of ring) {
+      const dp = Math.max(decimalPlaces(pos[0]), decimalPlaces(pos[1]));
+      if (dp > PRECISION_LIMIT) {
+        precisionCount++;
+        if (dp > worstDp) {
+          worstDp = dp;
+          worstSample = pos;
+        }
+      }
+    }
+  });
+  if (precisionCount > 0) {
+    violations.push({
+      file,
+      rule: "precision",
+      severity: "error",
+      message: `${precisionCount} coord(s) exceed ${PRECISION_LIMIT} DP (worst: ${worstDp} DP, e.g. ${JSON.stringify(worstSample)})`,
+    });
+  }
+
+  return violations;
+}
+
+//  Cross-file check: duplicate prefix/suffix
+
+export function findDuplicatePrefixSuffix(
+  features: Map<string, Feature<Polygon | MultiPolygon>>,
+): Violation[] {
+  const seen = new Map<string, string[]>();
+  for (const [file, feature] of features) {
+    const props = feature.properties as {
+      prefix?: string[];
+      suffix?: string;
+    } | null;
+    if (!props || !Array.isArray(props.prefix)) continue;
+    const suffix = props.suffix || "APP";
+    for (const prefix of props.prefix) {
+      const key = `${prefix}|${suffix}`;
+      if (!seen.has(key)) seen.set(key, []);
+      seen.get(key)!.push(file);
+    }
+  }
+  const out: Violation[] = [];
+  for (const [key, files] of seen) {
+    const unique = Array.from(new Set(files));
+    if (unique.length > 1) {
+      for (const file of unique) {
+        out.push({
+          file,
+          rule: "duplicate-prefix-suffix",
+          severity: "error",
+          message: `prefix/suffix '${key.replace("|", "/")}' duplicated`,
+          relatedFiles: unique,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+//  --fix
+
+/** Returns the rewritten file content if any change is needed, else null. */
+export function applyFixes(raw: string): string | null {
+  let feature: Feature<Polygon | MultiPolygon>;
+  try {
+    feature = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  let mutated = false;
+
+  function mutateRing(ring: Position[]): Position[] {
+    const rounded = ring.map((pos) => {
+      const np: Position = [roundCoord(pos[0]), roundCoord(pos[1])];
+      if (np[0] !== pos[0] || np[1] !== pos[1]) mutated = true;
+      return np;
+    });
+    if (rounded.length > 0) {
+      const f = rounded[0];
+      const l = rounded[rounded.length - 1];
+      if (f[0] !== l[0] || f[1] !== l[1]) {
+        rounded.push([f[0], f[1]]);
+        mutated = true;
+      }
+    }
+    return rounded;
+  }
+
+  const geom = feature.geometry;
+  if (geom?.type === "Polygon") {
+    geom.coordinates = geom.coordinates.map((r) => mutateRing(r as Position[]));
+  } else if (geom?.type === "MultiPolygon") {
+    geom.coordinates = geom.coordinates.map((poly) =>
+      poly.map((r) => mutateRing(r as Position[])),
+    );
+  }
+
+  return mutated ? JSON.stringify(feature, null, 2) : null;
+}

--- a/scripts/bin/lib/geometry-checks.ts
+++ b/scripts/bin/lib/geometry-checks.ts
@@ -1,11 +1,11 @@
 // Geometry validation logic shared by validate-geometry.ts and
 // ownership-report.ts.
 
-import type { Feature, MultiPolygon, Polygon, Position } from "geojson";
+import type {Feature, MultiPolygon, Polygon, Position} from 'geojson';
 
 export const PRECISION_LIMIT = 7;
 
-export type Severity = "error" | "warning";
+export type Severity = 'error' | 'warning';
 
 export interface Violation {
   file: string;
@@ -24,9 +24,9 @@ export function eachRing(
 ): void {
   const geom = feature.geometry;
   if (!geom) return;
-  if (geom.type === "Polygon") {
+  if (geom.type === 'Polygon') {
     geom.coordinates.forEach((ring, ri) => cb(ring as Position[], 0, ri));
-  } else if (geom.type === "MultiPolygon") {
+  } else if (geom.type === 'MultiPolygon') {
     geom.coordinates.forEach((poly, pi) =>
       poly.forEach((ring, ri) => cb(ring as Position[], pi, ri)),
     );
@@ -36,14 +36,14 @@ export function eachRing(
 export function decimalPlaces(n: number): number {
   if (!Number.isFinite(n)) return 0;
   const s = n.toString();
-  if (s.includes("e") || s.includes("E")) {
+  if (s.includes('e') || s.includes('E')) {
     const [mantissa, expStr] = s.split(/[eE]/);
-    const dotIdx = mantissa.indexOf(".");
+    const dotIdx = mantissa.indexOf('.');
     const mantissaDp = dotIdx === -1 ? 0 : mantissa.length - dotIdx - 1;
     const exp = parseInt(expStr, 10);
     return Math.max(0, mantissaDp - exp);
   }
-  const dot = s.indexOf(".");
+  const dot = s.indexOf('.');
   return dot === -1 ? 0 : s.length - dot - 1;
 }
 
@@ -54,15 +54,10 @@ export function roundCoord(n: number): number {
 
 // Per-file checks
 
-export function runFileChecks(
-  file: string,
-  feature: Feature<Polygon | MultiPolygon>,
-): Violation[] {
+export function runFileChecks(file: string, feature: Feature<Polygon | MultiPolygon>): Violation[] {
   const violations: Violation[] = [];
   const where = (pi: number, ri: number) =>
-    feature.geometry.type === "MultiPolygon"
-      ? `polygon ${pi}, ring ${ri}`
-      : `ring ${ri}`;
+    feature.geometry.type === 'MultiPolygon' ? `polygon ${pi}, ring ${ri}` : `ring ${ri}`;
 
   // Closure
   eachRing(feature, (ring, pi, ri) => {
@@ -72,8 +67,8 @@ export function runFileChecks(
     if (f[0] !== l[0] || f[1] !== l[1]) {
       violations.push({
         file,
-        rule: "closure",
-        severity: "error",
+        rule: 'closure',
+        severity: 'error',
         message: `unclosed ring at ${where(pi, ri)}: first ${JSON.stringify(f)} != last ${JSON.stringify(l)}`,
       });
     }
@@ -83,7 +78,7 @@ export function runFileChecks(
   let precisionCount = 0;
   let worstDp = 0;
   let worstSample: Position | null = null;
-  eachRing(feature, (ring) => {
+  eachRing(feature, ring => {
     for (const pos of ring) {
       const dp = Math.max(decimalPlaces(pos[0]), decimalPlaces(pos[1]));
       if (dp > PRECISION_LIMIT) {
@@ -98,8 +93,8 @@ export function runFileChecks(
   if (precisionCount > 0) {
     violations.push({
       file,
-      rule: "precision",
-      severity: "error",
+      rule: 'precision',
+      severity: 'error',
       message: `${precisionCount} coord(s) exceed ${PRECISION_LIMIT} DP (worst: ${worstDp} DP, e.g. ${JSON.stringify(worstSample)})`,
     });
   }
@@ -119,7 +114,7 @@ export function findDuplicatePrefixSuffix(
       suffix?: string;
     } | null;
     if (!props || !Array.isArray(props.prefix)) continue;
-    const suffix = props.suffix || "APP";
+    const suffix = props.suffix || 'APP';
     for (const prefix of props.prefix) {
       const key = `${prefix}|${suffix}`;
       if (!seen.has(key)) seen.set(key, []);
@@ -133,9 +128,9 @@ export function findDuplicatePrefixSuffix(
       for (const file of unique) {
         out.push({
           file,
-          rule: "duplicate-prefix-suffix",
-          severity: "error",
-          message: `prefix/suffix '${key.replace("|", "/")}' duplicated`,
+          rule: 'duplicate-prefix-suffix',
+          severity: 'error',
+          message: `prefix/suffix '${key.replace('|', '/')}' duplicated`,
           relatedFiles: unique,
         });
       }
@@ -157,7 +152,7 @@ export function applyFixes(raw: string): string | null {
   let mutated = false;
 
   function mutateRing(ring: Position[]): Position[] {
-    const rounded = ring.map((pos) => {
+    const rounded = ring.map(pos => {
       const np: Position = [roundCoord(pos[0]), roundCoord(pos[1])];
       if (np[0] !== pos[0] || np[1] !== pos[1]) mutated = true;
       return np;
@@ -174,12 +169,10 @@ export function applyFixes(raw: string): string | null {
   }
 
   const geom = feature.geometry;
-  if (geom?.type === "Polygon") {
-    geom.coordinates = geom.coordinates.map((r) => mutateRing(r as Position[]));
-  } else if (geom?.type === "MultiPolygon") {
-    geom.coordinates = geom.coordinates.map((poly) =>
-      poly.map((r) => mutateRing(r as Position[])),
-    );
+  if (geom?.type === 'Polygon') {
+    geom.coordinates = geom.coordinates.map(r => mutateRing(r as Position[]));
+  } else if (geom?.type === 'MultiPolygon') {
+    geom.coordinates = geom.coordinates.map(poly => poly.map(r => mutateRing(r as Position[])));
   }
 
   return mutated ? JSON.stringify(feature, null, 2) : null;

--- a/scripts/bin/lib/traverse.ts
+++ b/scripts/bin/lib/traverse.ts
@@ -1,5 +1,5 @@
-import { lstatSync, readdirSync } from "node:fs";
-import { dirname, extname, join } from "node:path";
+import {lstatSync, readdirSync} from 'node:fs';
+import {dirname, extname, join} from 'node:path';
 
 export function findJsonFiles(rootDir: string): string[] {
   const files: string[] = [];
@@ -9,8 +9,8 @@ export function findJsonFiles(rootDir: string): string[] {
       if (lstatSync(fullPath).isDirectory()) {
         walk(fullPath);
       } else if (
-        !dirname(fullPath).toLowerCase().includes("node_modules") &&
-        extname(fullPath).toLowerCase() === ".json"
+        !dirname(fullPath).toLowerCase().includes('node_modules') &&
+        extname(fullPath).toLowerCase() === '.json'
       ) {
         files.push(fullPath);
       }

--- a/scripts/bin/lib/traverse.ts
+++ b/scripts/bin/lib/traverse.ts
@@ -1,0 +1,21 @@
+import { lstatSync, readdirSync } from "node:fs";
+import { dirname, extname, join } from "node:path";
+
+export function findJsonFiles(rootDir: string): string[] {
+  const files: string[] = [];
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir)) {
+      const fullPath = join(dir, entry);
+      if (lstatSync(fullPath).isDirectory()) {
+        walk(fullPath);
+      } else if (
+        !dirname(fullPath).toLowerCase().includes("node_modules") &&
+        extname(fullPath).toLowerCase() === ".json"
+      ) {
+        files.push(fullPath);
+      }
+    }
+  }
+  walk(rootDir);
+  return files;
+}

--- a/scripts/bin/ownership-report.ts
+++ b/scripts/bin/ownership-report.ts
@@ -217,15 +217,32 @@ async function loadContributorIndex(): Promise<Map<string, ContributorRow>> {
   return idx;
 }
 
+/**
+ * Extract the GitHub username from a github.com noreply email.
+ *   modern: 12345678+username@users.noreply.github.com  -> username
+ *   legacy: username@users.noreply.github.com           -> username
+ * Returns null for any other email.
+ */
+function extractGithubUsername(email: string): string | null {
+  const m = email
+    .toLowerCase()
+    .trim()
+    .match(
+      /^(?:\d+\+)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)@users\.noreply\.github\.com$/,
+    );
+  return m ? m[1] : null;
+}
+
 function lookupContributor(
   author: AuthorAttribution,
   idx: Map<string, ContributorRow>,
 ): ContributorRow | null {
-  return (
-    idx.get(author.name.toLowerCase().trim()) ??
-    idx.get(author.email.toLowerCase().trim().split("@")[0]) ??
-    null
-  );
+  const ghUser = extractGithubUsername(author.email);
+  if (ghUser) {
+    const hit = idx.get(ghUser);
+    if (hit) return hit;
+  }
+  return idx.get(author.name.toLowerCase().trim()) ?? null;
 }
 
 // --- Types -------------------------------------------------------------------
@@ -419,9 +436,11 @@ function renderReport(
   for (const [, files] of sortedAuthors) {
     const author = files[0].primary!;
     const contributor = lookupContributor(author, contributorIdx);
+    const ghUser = extractGithubUsername(author.email);
+    const ghHint = ghUser ? ` — gh: \`${ghUser}\`` : "";
     const status = contributor
       ? `**${contributor.name || author.name}** (${contributor.username || "—"}, ${contributor.region || "—"}, role: ${contributor.role || "—"}, expires ${contributor.expiry || "—"})`
-      : `**${author.name}** \`<${author.email}>\` *(not in contributor spreadsheet)*`;
+      : `**${author.name}** \`<${author.email}>\`${ghHint} *(not in contributor spreadsheet)*`;
     out.push(`### ${status} — ${files.length} file(s)`);
     out.push("");
     for (const e of files.sort((a, b) => a.relPath.localeCompare(b.relPath))) {

--- a/scripts/bin/ownership-report.ts
+++ b/scripts/bin/ownership-report.ts
@@ -1,0 +1,478 @@
+// Generates a markdown report grouping geometry violations by primary
+// contributor
+//
+// "Bulk-move" commits — commits that touched a very large number of files in
+// one go are filtered out so they don't claim attribution they shouldn't have.
+// Bulk commits are detected by file count, not by author; pass --bulk-threshold to
+// tune. Files with no remaining attributable author after filtering are
+// flagged as **orphaned**
+//
+// Usage:
+//   yarn ownership-report > OWNERSHIP_REPORT.md
+//   yarn ownership-report --bulk-threshold=150
+//   yarn ownership-report --exclude-sha=abc123,def456
+
+import { fileURLToPath } from "url";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "fs";
+import { join, relative } from "path";
+import { parseArgs } from "node:util";
+import { parse as parseCsv } from "csv-parse/sync";
+import type { Feature, MultiPolygon, Polygon } from "geojson";
+import { findJsonFiles } from "./lib/traverse.ts";
+import {
+  type Violation,
+  findDuplicatePrefixSuffix,
+  runFileChecks,
+} from "./lib/geometry-checks.ts";
+
+// --- Configuration -----------------------------------------------------------
+
+const DEFAULT_BULK_THRESHOLD = 100;
+const CONTRIBUTOR_CSV_URL =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pub?gid=0&single=true&output=csv";
+
+// --- CLI ---------------------------------------------------------------------
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    "bulk-threshold": { type: "string" },
+    "exclude-sha": { type: "string" },
+    help: { type: "boolean", short: "h" },
+  },
+});
+
+if (values.help) {
+  console.log(`Usage: ownership-report [options]
+
+Generates a markdown report grouping geometry violations by primary git
+author. Output goes to stdout — pipe to a file (e.g. OWNERSHIP_REPORT.md).
+
+Options:
+  --bulk-threshold=N   Commits touching more than N files are treated as
+                       structural/bulk and excluded from attribution
+                       (default: ${DEFAULT_BULK_THRESHOLD}).
+  --exclude-sha=A,B,C  Additional commit SHAs to exclude from attribution.
+  -h, --help           Show this help.`);
+  process.exit(0);
+}
+
+const bulkThreshold = values["bulk-threshold"]
+  ? parseInt(values["bulk-threshold"], 10)
+  : DEFAULT_BULK_THRESHOLD;
+if (!Number.isFinite(bulkThreshold) || bulkThreshold < 1) {
+  console.error(`Invalid --bulk-threshold: ${values["bulk-threshold"]}`);
+  process.exit(2);
+}
+
+const explicitExcludes = new Set(
+  (values["exclude-sha"] ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+// --- Setup -------------------------------------------------------------------
+
+const scriptPath = fileURLToPath(new URL(import.meta.url).toString());
+const rootPath = join(scriptPath, "../../../");
+const boundariesDir = join(rootPath, "Boundaries");
+
+// --- Bulk commit detection ---------------------------------------------------
+
+function detectBulkCommits(threshold: number): Map<string, number> {
+  // Walk every commit reachable from any ref, collecting file-change count
+  // per commit via --shortstat. Returns a map of SHA -> filesChanged for
+  // commits exceeding the threshold.
+  const out = execFileSync(
+    "git",
+    ["log", "--all", "--shortstat", "--format=COMMIT %H"],
+    { cwd: rootPath, encoding: "utf8", maxBuffer: 256 * 1024 * 1024 },
+  );
+  const result = new Map<string, number>();
+  let currentSha: string | null = null;
+  for (const line of out.split("\n")) {
+    if (line.startsWith("COMMIT ")) {
+      currentSha = line.slice(7).trim().toLowerCase();
+    } else if (currentSha && /files? changed/.test(line)) {
+      const m = line.match(/(\d+) files? changed/);
+      if (m) {
+        const count = parseInt(m[1], 10);
+        if (count > threshold) {
+          result.set(currentSha, count);
+        }
+      }
+      currentSha = null;
+    }
+  }
+  return result;
+}
+
+// --- Git attribution ---------------------------------------------------------
+
+interface CommitRecord {
+  sha: string;
+  name: string;
+  email: string;
+  date: string;
+}
+
+interface AuthorAttribution {
+  name: string;
+  email: string;
+  commitCount: number;
+  lastTouched: string;
+}
+
+function gitFileHistory(file: string): CommitRecord[] {
+  let out: string;
+  try {
+    out = execFileSync(
+      "git",
+      ["log", "--follow", "--format=%H|%an|%ae|%aI", "--", file],
+      { cwd: rootPath, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+    );
+  } catch {
+    return [];
+  }
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, name, email, date] = line.split("|");
+      return {
+        sha: (sha ?? "").toLowerCase(),
+        name: name ?? "",
+        email: email ?? "",
+        date: date ?? "",
+      };
+    });
+}
+
+function attribute(
+  file: string,
+  excludedShas: Set<string>,
+): { primary: AuthorAttribution | null; all: AuthorAttribution[] } {
+  const history = gitFileHistory(file);
+  const filtered = history.filter((c) => !excludedShas.has(c.sha));
+  if (filtered.length === 0) return { primary: null, all: [] };
+
+  const groups = new Map<string, AuthorAttribution>();
+  for (const c of filtered) {
+    const key = `${c.name}|${c.email.toLowerCase()}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.commitCount++;
+      if (c.date > existing.lastTouched) existing.lastTouched = c.date;
+    } else {
+      groups.set(key, {
+        name: c.name,
+        email: c.email,
+        commitCount: 1,
+        lastTouched: c.date,
+      });
+    }
+  }
+  const all = Array.from(groups.values()).sort((a, b) => {
+    if (a.commitCount !== b.commitCount) return b.commitCount - a.commitCount;
+    return b.lastTouched.localeCompare(a.lastTouched);
+  });
+  return { primary: all[0], all };
+}
+
+// --- Contributor CSV ---------------------------------------------------------
+
+interface ContributorRow {
+  username: string;
+  expiry: string;
+  cid: string;
+  name: string;
+  region: string;
+  role: string;
+  approvingCid: string;
+  approvingStaff: string;
+}
+
+async function loadContributorIndex(): Promise<Map<string, ContributorRow>> {
+  const csv = await (await fetch(CONTRIBUTOR_CSV_URL)).text();
+  const rows = parseCsv<ContributorRow>(csv, {
+    columns: [
+      "username",
+      "expiry",
+      "cid",
+      "name",
+      "region",
+      "role",
+      "approvingCid",
+      "approvingStaff",
+    ],
+    skip_empty_lines: true,
+  });
+  const idx = new Map<string, ContributorRow>();
+  for (const row of rows) {
+    if (row.name) idx.set(row.name.toLowerCase().trim(), row);
+    if (row.username) idx.set(row.username.toLowerCase().trim(), row);
+  }
+  return idx;
+}
+
+function lookupContributor(
+  author: AuthorAttribution,
+  idx: Map<string, ContributorRow>,
+): ContributorRow | null {
+  return (
+    idx.get(author.name.toLowerCase().trim()) ??
+    idx.get(author.email.toLowerCase().trim().split("@")[0]) ??
+    null
+  );
+}
+
+// --- Types -------------------------------------------------------------------
+
+interface FileEntry {
+  file: string;
+  relPath: string;
+  rules: Set<string>;
+  primary: AuthorAttribution | null;
+  allAuthors: AuthorAttribution[];
+}
+
+// --- Main --------------------------------------------------------------------
+
+async function main() {
+  console.error("Detecting bulk-move commits...");
+  const detectedBulk = detectBulkCommits(bulkThreshold);
+  const excludedShas = new Set<string>([
+    ...detectedBulk.keys(),
+    ...explicitExcludes,
+  ]);
+  console.error(
+    `  ${detectedBulk.size} commit(s) exceed --bulk-threshold=${bulkThreshold} (excluded from attribution)` +
+      (explicitExcludes.size > 0
+        ? `; +${explicitExcludes.size} explicit --exclude-sha`
+        : ""),
+  );
+  if (detectedBulk.size > 0) {
+    const top = [...detectedBulk.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+    for (const [sha, files] of top) {
+      console.error(`    ${sha.slice(0, 12)}  ${files} files`);
+    }
+  }
+
+  console.error("Scanning Boundaries/ ...");
+  const allFiles = findJsonFiles(boundariesDir);
+  const featuresByFile = new Map<string, Feature<Polygon | MultiPolygon>>();
+  const violations: Violation[] = [];
+
+  for (const filePath of allFiles) {
+    const raw = readFileSync(filePath, "utf8");
+    let feature: Feature<Polygon | MultiPolygon>;
+    try {
+      feature = JSON.parse(raw);
+    } catch (e) {
+      violations.push({
+        file: filePath,
+        rule: "json-parse",
+        severity: "error",
+        message: `Invalid JSON: ${(e as Error).message}`,
+      });
+      continue;
+    }
+    featuresByFile.set(filePath, feature);
+    violations.push(...runFileChecks(filePath, feature));
+  }
+  violations.push(...findDuplicatePrefixSuffix(featuresByFile));
+
+  const perFile = new Map<string, FileEntry>();
+  for (const v of violations) {
+    const rel = relative(rootPath, v.file).replace(/\\/g, "/");
+    if (!perFile.has(v.file)) {
+      perFile.set(v.file, {
+        file: v.file,
+        relPath: rel,
+        rules: new Set(),
+        primary: null,
+        allAuthors: [],
+      });
+    }
+    perFile.get(v.file)!.rules.add(v.rule);
+  }
+
+  console.error(`Attributing ${perFile.size} files via git log...`);
+  let i = 0;
+  for (const entry of perFile.values()) {
+    if (++i % 100 === 0) console.error(`  ... ${i}/${perFile.size}`);
+    const { primary, all } = attribute(entry.file, excludedShas);
+    entry.primary = primary;
+    entry.allAuthors = all;
+  }
+
+  console.error("Fetching contributor spreadsheet...");
+  let contributorIdx: Map<string, ContributorRow>;
+  try {
+    contributorIdx = await loadContributorIndex();
+  } catch (e) {
+    console.error(
+      `(failed: ${(e as Error).message}; continuing without contributor metadata)`,
+    );
+    contributorIdx = new Map();
+  }
+
+  renderReport(perFile, violations, contributorIdx, {
+    bulkThreshold,
+    bulkCommitsExcluded: detectedBulk.size,
+    explicitExcludes: explicitExcludes.size,
+  });
+}
+
+interface ReportMeta {
+  bulkThreshold: number;
+  bulkCommitsExcluded: number;
+  explicitExcludes: number;
+}
+
+function renderReport(
+  perFile: Map<string, FileEntry>,
+  allViolations: Violation[],
+  contributorIdx: Map<string, ContributorRow>,
+  meta: ReportMeta,
+) {
+  const out: string[] = [];
+  const today = new Date().toISOString().slice(0, 10);
+
+  const errorRules = new Map<string, number>();
+  const warningRules = new Map<string, number>();
+  for (const v of allViolations) {
+    const m = v.severity === "error" ? errorRules : warningRules;
+    m.set(v.rule, (m.get(v.rule) ?? 0) + 1);
+  }
+
+  out.push(`# Cleanup Ownership Report — ${today}`);
+  out.push("");
+  out.push(
+    `Generated by \`yarn ownership-report\`. Commits that touched more than \`${meta.bulkThreshold}\` files are excluded from attribution as structural/bulk operations (\`${meta.bulkCommitsExcluded}\` such commit(s) detected${meta.explicitExcludes > 0 ? `; +${meta.explicitExcludes} explicit --exclude-sha` : ""}). Files with no remaining attributable author are flagged as **orphaned**.`,
+  );
+  out.push("");
+
+  out.push("## Summary");
+  out.push("");
+  out.push(`- Files with at least one violation: **${perFile.size}**`);
+  out.push("");
+  out.push("### Errors");
+  out.push("");
+  for (const [rule, count] of [...errorRules.entries()].sort(
+    (a, b) => b[1] - a[1],
+  )) {
+    out.push(`- \`${rule}\`: ${count}`);
+  }
+  out.push("");
+  out.push("### Warnings");
+  out.push("");
+  for (const [rule, count] of [...warningRules.entries()].sort(
+    (a, b) => b[1] - a[1],
+  )) {
+    out.push(`- \`${rule}\`: ${count}`);
+  }
+  out.push("");
+
+  const orphans = [...perFile.values()].filter((e) => e.primary === null);
+  out.push(`## Orphaned files — ${orphans.length}`);
+  out.push("");
+  if (orphans.length === 0) {
+    out.push(
+      "_(none — every violating file has at least one non-bulk-move author)_",
+    );
+  } else {
+    out.push(
+      "Files where every commit was filtered as bulk/structural. The maintainer must reclaim or rebuild attribution for these.",
+    );
+    out.push("");
+    out.push("| File | Violations |");
+    out.push("|---|---|");
+    for (const e of orphans.sort((a, b) =>
+      a.relPath.localeCompare(b.relPath),
+    )) {
+      out.push(`| \`${e.relPath}\` | ${[...e.rules].sort().join(", ")} |`);
+    }
+  }
+  out.push("");
+
+  const byAuthor = new Map<string, FileEntry[]>();
+  for (const e of perFile.values()) {
+    if (!e.primary) continue;
+    const key = `${e.primary.name}|${e.primary.email.toLowerCase()}`;
+    if (!byAuthor.has(key)) byAuthor.set(key, []);
+    byAuthor.get(key)!.push(e);
+  }
+  const sortedAuthors = [...byAuthor.entries()].sort(
+    (a, b) => b[1].length - a[1].length,
+  );
+
+  out.push(
+    `## Files by primary author — ${sortedAuthors.length} contributor(s)`,
+  );
+  out.push("");
+
+  for (const [, files] of sortedAuthors) {
+    const author = files[0].primary!;
+    const contributor = lookupContributor(author, contributorIdx);
+    const status = contributor
+      ? `**${contributor.name || author.name}** (${contributor.username || "—"}, ${contributor.region || "—"}, role: ${contributor.role || "—"}, expires ${contributor.expiry || "—"})`
+      : `**${author.name}** \`<${author.email}>\` *(not in contributor spreadsheet)*`;
+    out.push(`### ${status} — ${files.length} file(s)`);
+    out.push("");
+    for (const e of files.sort((a, b) => a.relPath.localeCompare(b.relPath))) {
+      const otherAuthors = e.allAuthors
+        .slice(1)
+        .map((a) => `${a.name} (${a.commitCount})`)
+        .join(", ");
+      const others = otherAuthors ? ` — also: ${otherAuthors}` : "";
+      const last = e.primary!.lastTouched.slice(0, 10);
+      out.push(
+        `- [ ] \`${e.relPath}\` — ${[...e.rules].sort().join(", ")} — ${e.primary!.commitCount} commit(s), last ${last}${others}`,
+      );
+    }
+    out.push("");
+  }
+
+  const dupes = allViolations.filter(
+    (v) => v.rule === "duplicate-prefix-suffix",
+  );
+  if (dupes.length > 0) {
+    out.push("## Duplicate prefix/suffix pairs (manual resolution required)");
+    out.push("");
+    out.push(
+      "Each pair below has two or more files matching the same `(prefix, suffix)`. One file in each group must be renamed (different prefix/suffix) or deleted.",
+    );
+    out.push("");
+    const grouped = new Map<string, Set<string>>();
+    for (const v of dupes) {
+      const m = v.message.match(/'([^']+)'/);
+      if (!m) continue;
+      const key = m[1];
+      if (!grouped.has(key)) grouped.set(key, new Set());
+      (v.relatedFiles ?? []).forEach((f) =>
+        grouped.get(key)!.add(relative(rootPath, f).replace(/\\/g, "/")),
+      );
+    }
+    for (const [key, files] of grouped) {
+      out.push(
+        `- \`${key}\` — ${[...files]
+          .sort()
+          .map((f) => `\`${f}\``)
+          .join(" + ")}`,
+      );
+    }
+    out.push("");
+  }
+
+  process.stdout.write(out.join("\n") + "\n");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/bin/ownership-report.ts
+++ b/scripts/bin/ownership-report.ts
@@ -12,34 +12,30 @@
 //   yarn ownership-report --bulk-threshold=150
 //   yarn ownership-report --exclude-sha=abc123,def456
 
-import { fileURLToPath } from "url";
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "fs";
-import { join, relative } from "path";
-import { parseArgs } from "node:util";
-import { parse as parseCsv } from "csv-parse/sync";
-import type { Feature, MultiPolygon, Polygon } from "geojson";
-import { findJsonFiles } from "./lib/traverse.ts";
-import {
-  type Violation,
-  findDuplicatePrefixSuffix,
-  runFileChecks,
-} from "./lib/geometry-checks.ts";
+import {fileURLToPath} from 'url';
+import {execFileSync} from 'node:child_process';
+import {readFileSync} from 'fs';
+import {join, relative} from 'path';
+import {parseArgs} from 'node:util';
+import {parse as parseCsv} from 'csv-parse/sync';
+import type {Feature, MultiPolygon, Polygon} from 'geojson';
+import {findJsonFiles} from './lib/traverse.ts';
+import {type Violation, findDuplicatePrefixSuffix, runFileChecks} from './lib/geometry-checks.ts';
 
 // --- Configuration -----------------------------------------------------------
 
 const DEFAULT_BULK_THRESHOLD = 100;
 const CONTRIBUTOR_CSV_URL =
-  "https://docs.google.com/spreadsheets/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pub?gid=0&single=true&output=csv";
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vRHzHhKz4icslNkd3I6mF1Mp_6gan4muRcWZb8fCYL8_S0C6GDpG409xQGTmPAXLPupEWWws3euNK7O/pub?gid=0&single=true&output=csv';
 
 // --- CLI ---------------------------------------------------------------------
 
-const { values } = parseArgs({
+const {values} = parseArgs({
   args: process.argv.slice(2),
   options: {
-    "bulk-threshold": { type: "string" },
-    "exclude-sha": { type: "string" },
-    help: { type: "boolean", short: "h" },
+    'bulk-threshold': {type: 'string'},
+    'exclude-sha': {type: 'string'},
+    help: {type: 'boolean', short: 'h'},
   },
 });
 
@@ -58,26 +54,26 @@ Options:
   process.exit(0);
 }
 
-const bulkThreshold = values["bulk-threshold"]
-  ? parseInt(values["bulk-threshold"], 10)
+const bulkThreshold = values['bulk-threshold']
+  ? parseInt(values['bulk-threshold'], 10)
   : DEFAULT_BULK_THRESHOLD;
 if (!Number.isFinite(bulkThreshold) || bulkThreshold < 1) {
-  console.error(`Invalid --bulk-threshold: ${values["bulk-threshold"]}`);
+  console.error(`Invalid --bulk-threshold: ${values['bulk-threshold']}`);
   process.exit(2);
 }
 
 const explicitExcludes = new Set(
-  (values["exclude-sha"] ?? "")
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
+  (values['exclude-sha'] ?? '')
+    .split(',')
+    .map(s => s.trim().toLowerCase())
     .filter(Boolean),
 );
 
 // --- Setup -------------------------------------------------------------------
 
 const scriptPath = fileURLToPath(new URL(import.meta.url).toString());
-const rootPath = join(scriptPath, "../../../");
-const boundariesDir = join(rootPath, "Boundaries");
+const rootPath = join(scriptPath, '../../../');
+const boundariesDir = join(rootPath, 'Boundaries');
 
 // --- Bulk commit detection ---------------------------------------------------
 
@@ -85,15 +81,15 @@ function detectBulkCommits(threshold: number): Map<string, number> {
   // Walk every commit reachable from any ref, collecting file-change count
   // per commit via --shortstat. Returns a map of SHA -> filesChanged for
   // commits exceeding the threshold.
-  const out = execFileSync(
-    "git",
-    ["log", "--all", "--shortstat", "--format=COMMIT %H"],
-    { cwd: rootPath, encoding: "utf8", maxBuffer: 256 * 1024 * 1024 },
-  );
+  const out = execFileSync('git', ['log', '--all', '--shortstat', '--format=COMMIT %H'], {
+    cwd: rootPath,
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
   const result = new Map<string, number>();
   let currentSha: string | null = null;
-  for (const line of out.split("\n")) {
-    if (line.startsWith("COMMIT ")) {
+  for (const line of out.split('\n')) {
+    if (line.startsWith('COMMIT ')) {
       currentSha = line.slice(7).trim().toLowerCase();
     } else if (currentSha && /files? changed/.test(line)) {
       const m = line.match(/(\d+) files? changed/);
@@ -128,24 +124,24 @@ interface AuthorAttribution {
 function gitFileHistory(file: string): CommitRecord[] {
   let out: string;
   try {
-    out = execFileSync(
-      "git",
-      ["log", "--follow", "--format=%H|%an|%ae|%aI", "--", file],
-      { cwd: rootPath, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
-    );
+    out = execFileSync('git', ['log', '--follow', '--format=%H|%an|%ae|%aI', '--', file], {
+      cwd: rootPath,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
   } catch {
     return [];
   }
   return out
-    .split("\n")
+    .split('\n')
     .filter(Boolean)
-    .map((line) => {
-      const [sha, name, email, date] = line.split("|");
+    .map(line => {
+      const [sha, name, email, date] = line.split('|');
       return {
-        sha: (sha ?? "").toLowerCase(),
-        name: name ?? "",
-        email: email ?? "",
-        date: date ?? "",
+        sha: (sha ?? '').toLowerCase(),
+        name: name ?? '',
+        email: email ?? '',
+        date: date ?? '',
       };
     });
 }
@@ -153,10 +149,10 @@ function gitFileHistory(file: string): CommitRecord[] {
 function attribute(
   file: string,
   excludedShas: Set<string>,
-): { primary: AuthorAttribution | null; all: AuthorAttribution[] } {
+): {primary: AuthorAttribution | null; all: AuthorAttribution[]} {
   const history = gitFileHistory(file);
-  const filtered = history.filter((c) => !excludedShas.has(c.sha));
-  if (filtered.length === 0) return { primary: null, all: [] };
+  const filtered = history.filter(c => !excludedShas.has(c.sha));
+  if (filtered.length === 0) return {primary: null, all: []};
 
   const groups = new Map<string, AuthorAttribution>();
   for (const c of filtered) {
@@ -178,7 +174,7 @@ function attribute(
     if (a.commitCount !== b.commitCount) return b.commitCount - a.commitCount;
     return b.lastTouched.localeCompare(a.lastTouched);
   });
-  return { primary: all[0], all };
+  return {primary: all[0], all};
 }
 
 // --- Contributor CSV ---------------------------------------------------------
@@ -198,14 +194,14 @@ async function loadContributorIndex(): Promise<Map<string, ContributorRow>> {
   const csv = await (await fetch(CONTRIBUTOR_CSV_URL)).text();
   const rows = parseCsv<ContributorRow>(csv, {
     columns: [
-      "username",
-      "expiry",
-      "cid",
-      "name",
-      "region",
-      "role",
-      "approvingCid",
-      "approvingStaff",
+      'username',
+      'expiry',
+      'cid',
+      'name',
+      'region',
+      'role',
+      'approvingCid',
+      'approvingStaff',
     ],
     skip_empty_lines: true,
   });
@@ -227,9 +223,7 @@ function extractGithubUsername(email: string): string | null {
   const m = email
     .toLowerCase()
     .trim()
-    .match(
-      /^(?:\d+\+)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)@users\.noreply\.github\.com$/,
-    );
+    .match(/^(?:\d+\+)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)@users\.noreply\.github\.com$/);
   return m ? m[1] : null;
 }
 
@@ -258,42 +252,35 @@ interface FileEntry {
 // --- Main --------------------------------------------------------------------
 
 async function main() {
-  console.error("Detecting bulk-move commits...");
+  console.error('Detecting bulk-move commits...');
   const detectedBulk = detectBulkCommits(bulkThreshold);
-  const excludedShas = new Set<string>([
-    ...detectedBulk.keys(),
-    ...explicitExcludes,
-  ]);
+  const excludedShas = new Set<string>([...detectedBulk.keys(), ...explicitExcludes]);
   console.error(
     `  ${detectedBulk.size} commit(s) exceed --bulk-threshold=${bulkThreshold} (excluded from attribution)` +
-      (explicitExcludes.size > 0
-        ? `; +${explicitExcludes.size} explicit --exclude-sha`
-        : ""),
+      (explicitExcludes.size > 0 ? `; +${explicitExcludes.size} explicit --exclude-sha` : ''),
   );
   if (detectedBulk.size > 0) {
-    const top = [...detectedBulk.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5);
+    const top = [...detectedBulk.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
     for (const [sha, files] of top) {
       console.error(`    ${sha.slice(0, 12)}  ${files} files`);
     }
   }
 
-  console.error("Scanning Boundaries/ ...");
+  console.error('Scanning Boundaries/ ...');
   const allFiles = findJsonFiles(boundariesDir);
   const featuresByFile = new Map<string, Feature<Polygon | MultiPolygon>>();
   const violations: Violation[] = [];
 
   for (const filePath of allFiles) {
-    const raw = readFileSync(filePath, "utf8");
+    const raw = readFileSync(filePath, 'utf8');
     let feature: Feature<Polygon | MultiPolygon>;
     try {
       feature = JSON.parse(raw);
     } catch (e) {
       violations.push({
         file: filePath,
-        rule: "json-parse",
-        severity: "error",
+        rule: 'json-parse',
+        severity: 'error',
         message: `Invalid JSON: ${(e as Error).message}`,
       });
       continue;
@@ -305,7 +292,7 @@ async function main() {
 
   const perFile = new Map<string, FileEntry>();
   for (const v of violations) {
-    const rel = relative(rootPath, v.file).replace(/\\/g, "/");
+    const rel = relative(rootPath, v.file).replace(/\\/g, '/');
     if (!perFile.has(v.file)) {
       perFile.set(v.file, {
         file: v.file,
@@ -322,19 +309,17 @@ async function main() {
   let i = 0;
   for (const entry of perFile.values()) {
     if (++i % 100 === 0) console.error(`  ... ${i}/${perFile.size}`);
-    const { primary, all } = attribute(entry.file, excludedShas);
+    const {primary, all} = attribute(entry.file, excludedShas);
     entry.primary = primary;
     entry.allAuthors = all;
   }
 
-  console.error("Fetching contributor spreadsheet...");
+  console.error('Fetching contributor spreadsheet...');
   let contributorIdx: Map<string, ContributorRow>;
   try {
     contributorIdx = await loadContributorIndex();
   } catch (e) {
-    console.error(
-      `(failed: ${(e as Error).message}; continuing without contributor metadata)`,
-    );
+    console.error(`(failed: ${(e as Error).message}; continuing without contributor metadata)`);
     contributorIdx = new Map();
   }
 
@@ -363,59 +348,51 @@ function renderReport(
   const errorRules = new Map<string, number>();
   const warningRules = new Map<string, number>();
   for (const v of allViolations) {
-    const m = v.severity === "error" ? errorRules : warningRules;
+    const m = v.severity === 'error' ? errorRules : warningRules;
     m.set(v.rule, (m.get(v.rule) ?? 0) + 1);
   }
 
   out.push(`# Cleanup Ownership Report — ${today}`);
-  out.push("");
+  out.push('');
   out.push(
-    `Generated by \`yarn ownership-report\`. Commits that touched more than \`${meta.bulkThreshold}\` files are excluded from attribution as structural/bulk operations (\`${meta.bulkCommitsExcluded}\` such commit(s) detected${meta.explicitExcludes > 0 ? `; +${meta.explicitExcludes} explicit --exclude-sha` : ""}). Files with no remaining attributable author are flagged as **orphaned**.`,
+    `Generated by \`yarn ownership-report\`. Commits that touched more than \`${meta.bulkThreshold}\` files are excluded from attribution as structural/bulk operations (\`${meta.bulkCommitsExcluded}\` such commit(s) detected${meta.explicitExcludes > 0 ? `; +${meta.explicitExcludes} explicit --exclude-sha` : ''}). Files with no remaining attributable author are flagged as **orphaned**.`,
   );
-  out.push("");
+  out.push('');
 
-  out.push("## Summary");
-  out.push("");
+  out.push('## Summary');
+  out.push('');
   out.push(`- Files with at least one violation: **${perFile.size}**`);
-  out.push("");
-  out.push("### Errors");
-  out.push("");
-  for (const [rule, count] of [...errorRules.entries()].sort(
-    (a, b) => b[1] - a[1],
-  )) {
+  out.push('');
+  out.push('### Errors');
+  out.push('');
+  for (const [rule, count] of [...errorRules.entries()].sort((a, b) => b[1] - a[1])) {
     out.push(`- \`${rule}\`: ${count}`);
   }
-  out.push("");
-  out.push("### Warnings");
-  out.push("");
-  for (const [rule, count] of [...warningRules.entries()].sort(
-    (a, b) => b[1] - a[1],
-  )) {
+  out.push('');
+  out.push('### Warnings');
+  out.push('');
+  for (const [rule, count] of [...warningRules.entries()].sort((a, b) => b[1] - a[1])) {
     out.push(`- \`${rule}\`: ${count}`);
   }
-  out.push("");
+  out.push('');
 
-  const orphans = [...perFile.values()].filter((e) => e.primary === null);
+  const orphans = [...perFile.values()].filter(e => e.primary === null);
   out.push(`## Orphaned files — ${orphans.length}`);
-  out.push("");
+  out.push('');
   if (orphans.length === 0) {
-    out.push(
-      "_(none — every violating file has at least one non-bulk-move author)_",
-    );
+    out.push('_(none — every violating file has at least one non-bulk-move author)_');
   } else {
     out.push(
-      "Files where every commit was filtered as bulk/structural. The maintainer must reclaim or rebuild attribution for these.",
+      'Files where every commit was filtered as bulk/structural. The maintainer must reclaim or rebuild attribution for these.',
     );
-    out.push("");
-    out.push("| File | Violations |");
-    out.push("|---|---|");
-    for (const e of orphans.sort((a, b) =>
-      a.relPath.localeCompare(b.relPath),
-    )) {
-      out.push(`| \`${e.relPath}\` | ${[...e.rules].sort().join(", ")} |`);
+    out.push('');
+    out.push('| File | Violations |');
+    out.push('|---|---|');
+    for (const e of orphans.sort((a, b) => a.relPath.localeCompare(b.relPath))) {
+      out.push(`| \`${e.relPath}\` | ${[...e.rules].sort().join(', ')} |`);
     }
   }
-  out.push("");
+  out.push('');
 
   const byAuthor = new Map<string, FileEntry[]>();
   for (const e of perFile.values()) {
@@ -424,74 +401,68 @@ function renderReport(
     if (!byAuthor.has(key)) byAuthor.set(key, []);
     byAuthor.get(key)!.push(e);
   }
-  const sortedAuthors = [...byAuthor.entries()].sort(
-    (a, b) => b[1].length - a[1].length,
-  );
+  const sortedAuthors = [...byAuthor.entries()].sort((a, b) => b[1].length - a[1].length);
 
-  out.push(
-    `## Files by primary author — ${sortedAuthors.length} contributor(s)`,
-  );
-  out.push("");
+  out.push(`## Files by primary author — ${sortedAuthors.length} contributor(s)`);
+  out.push('');
 
   for (const [, files] of sortedAuthors) {
     const author = files[0].primary!;
     const contributor = lookupContributor(author, contributorIdx);
     const ghUser = extractGithubUsername(author.email);
-    const ghHint = ghUser ? ` — gh: \`${ghUser}\`` : "";
+    const ghHint = ghUser ? ` — gh: \`${ghUser}\`` : '';
     const status = contributor
-      ? `**${contributor.name || author.name}** (${contributor.username || "—"}, ${contributor.region || "—"}, role: ${contributor.role || "—"}, expires ${contributor.expiry || "—"})`
+      ? `**${contributor.name || author.name}** (${contributor.username || '—'}, ${contributor.region || '—'}, role: ${contributor.role || '—'}, expires ${contributor.expiry || '—'})`
       : `**${author.name}** \`<${author.email}>\`${ghHint} *(not in contributor spreadsheet)*`;
     out.push(`### ${status} — ${files.length} file(s)`);
-    out.push("");
+    out.push('');
     for (const e of files.sort((a, b) => a.relPath.localeCompare(b.relPath))) {
       const otherAuthors = e.allAuthors
         .slice(1)
-        .map((a) => `${a.name} (${a.commitCount})`)
-        .join(", ");
-      const others = otherAuthors ? ` — also: ${otherAuthors}` : "";
+        .map(a => `${a.name} (${a.commitCount})`)
+        .join(', ');
+      const others = otherAuthors ? ` — also: ${otherAuthors}` : '';
       const last = e.primary!.lastTouched.slice(0, 10);
       out.push(
-        `- [ ] \`${e.relPath}\` — ${[...e.rules].sort().join(", ")} — ${e.primary!.commitCount} commit(s), last ${last}${others}`,
+        `- [ ] \`${e.relPath}\` — ${[...e.rules].sort().join(', ')} — ${e.primary!.commitCount} commit(s), last ${last}${others}`,
       );
     }
-    out.push("");
+    out.push('');
   }
 
-  const dupes = allViolations.filter(
-    (v) => v.rule === "duplicate-prefix-suffix",
-  );
+  const dupes = allViolations.filter(v => v.rule === 'duplicate-prefix-suffix');
   if (dupes.length > 0) {
-    out.push("## Duplicate prefix/suffix pairs (manual resolution required)");
-    out.push("");
+    out.push('## Duplicate prefix/suffix pairs (manual resolution required)');
+    out.push('');
     out.push(
-      "Each pair below has two or more files matching the same `(prefix, suffix)`. One file in each group must be renamed (different prefix/suffix) or deleted.",
+      'Each pair below has two or more files matching the same `(prefix, suffix)`. One file in each group must be renamed (different prefix/suffix) or deleted.',
     );
-    out.push("");
+    out.push('');
     const grouped = new Map<string, Set<string>>();
     for (const v of dupes) {
       const m = v.message.match(/'([^']+)'/);
       if (!m) continue;
       const key = m[1];
       if (!grouped.has(key)) grouped.set(key, new Set());
-      (v.relatedFiles ?? []).forEach((f) =>
-        grouped.get(key)!.add(relative(rootPath, f).replace(/\\/g, "/")),
+      (v.relatedFiles ?? []).forEach(f =>
+        grouped.get(key)!.add(relative(rootPath, f).replace(/\\/g, '/')),
       );
     }
     for (const [key, files] of grouped) {
       out.push(
         `- \`${key}\` — ${[...files]
           .sort()
-          .map((f) => `\`${f}\``)
-          .join(" + ")}`,
+          .map(f => `\`${f}\``)
+          .join(' + ')}`,
       );
     }
-    out.push("");
+    out.push('');
   }
 
-  process.stdout.write(out.join("\n") + "\n");
+  process.stdout.write(out.join('\n') + '\n');
 }
 
-main().catch((e) => {
+main().catch(e => {
   console.error(e);
   process.exit(1);
 });

--- a/scripts/bin/validate-geometry.ts
+++ b/scripts/bin/validate-geometry.ts
@@ -1,0 +1,155 @@
+import { fileURLToPath } from "url";
+import { readFileSync, writeFileSync } from "fs";
+import { join, relative, resolve } from "path";
+import { parseArgs } from "node:util";
+import type { Feature, MultiPolygon, Polygon } from "geojson";
+import { findJsonFiles } from "./lib/traverse.ts";
+import {
+  type Violation,
+  applyFixes,
+  findDuplicatePrefixSuffix,
+  runFileChecks,
+} from "./lib/geometry-checks.ts";
+
+//  CLI
+
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    "changed-only": { type: "boolean" },
+    fix: { type: "boolean" },
+    help: { type: "boolean", short: "h" },
+  },
+  allowPositionals: true,
+});
+
+if (values.help) {
+  console.log(`Usage: validate-geometry [options] [files...]
+
+Options:
+  --changed-only   Only report errors in files passed as args (or via stdin).
+                   Cross-file checks (e.g. duplicate prefix/suffix) still run
+                   against the whole dataset, but are only reported when a
+                   changed file is involved.
+  --fix            Auto-fix closure and coordinate precision in place.
+                   Mutually exclusive with --changed-only.
+  -h, --help       Show this help.
+
+Exits non-zero on any violation.`);
+  process.exit(0);
+}
+
+const fix = !!values.fix;
+const changedOnly = !!values["changed-only"];
+
+if (fix && changedOnly) {
+  console.error("--fix and --changed-only are mutually exclusive");
+  process.exit(2);
+}
+
+//  Path discovery
+
+const scriptPath = fileURLToPath(new URL(import.meta.url).toString());
+const rootPath = join(scriptPath, "../../../");
+const boundariesDir = join(rootPath, "Boundaries");
+
+const allFiles = findJsonFiles(boundariesDir);
+
+function relSlash(file: string): string {
+  return relative(rootPath, file).replace(/\\/g, "/");
+}
+
+function resolveBoundaryPath(input: string): string | null {
+  const abs = resolve(rootPath, input);
+  return allFiles.find((f) => resolve(f) === abs) ?? null;
+}
+
+let changedSet: Set<string> | null = null;
+if (changedOnly) {
+  const inputs: string[] = [];
+  if (positionals.length > 0) {
+    inputs.push(...positionals);
+  } else if (!process.stdin.isTTY) {
+    const stdin = readFileSync(0, "utf8");
+    inputs.push(
+      ...stdin
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  }
+  const resolved = inputs
+    .map(resolveBoundaryPath)
+    .filter((p): p is string => p !== null);
+  changedSet = new Set(resolved);
+  if (changedSet.size === 0) {
+    console.log("No boundary files in changed set; nothing to validate.");
+    process.exit(0);
+  }
+}
+
+//  Main
+
+const violations: Violation[] = [];
+const featuresByFile = new Map<string, Feature<Polygon | MultiPolygon>>();
+
+for (const filePath of allFiles) {
+  const raw = readFileSync(filePath, "utf8");
+  let feature: Feature<Polygon | MultiPolygon>;
+  try {
+    feature = JSON.parse(raw);
+  } catch (e) {
+    violations.push({
+      file: filePath,
+      rule: "json-parse",
+      severity: "error",
+      message: `Invalid JSON: ${(e as Error).message}`,
+    });
+    continue;
+  }
+  featuresByFile.set(filePath, feature);
+
+  if (fix) {
+    const fixed = applyFixes(raw);
+    if (fixed !== null) {
+      writeFileSync(filePath, fixed);
+      console.log(`fixed: ${relSlash(filePath)}`);
+    }
+    continue;
+  }
+
+  violations.push(...runFileChecks(filePath, feature));
+}
+
+if (fix) {
+  console.log("Done. Re-run validate-geometry to confirm.");
+  process.exit(0);
+}
+
+violations.push(...findDuplicatePrefixSuffix(featuresByFile));
+
+//  Filter by changed set
+
+let toReport = violations;
+if (changedSet) {
+  toReport = violations.filter((v) => {
+    if (v.relatedFiles && v.relatedFiles.length > 0) {
+      return v.relatedFiles.some((f) => changedSet!.has(f));
+    }
+    return changedSet!.has(v.file);
+  });
+}
+
+//  Print
+
+for (const v of toReport) {
+  const extra = v.relatedFiles
+    ? ` (involves: ${v.relatedFiles.map((f) => relSlash(f)).join(", ")})`
+    : "";
+  console.error(`ERROR  ${relSlash(v.file)} [${v.rule}] ${v.message}${extra}`);
+}
+
+const summary = `${toReport.length} error(s)${changedSet ? ` across ${changedSet.size} changed file(s)` : ` across ${allFiles.length} file(s)`}`;
+console.log(`\n${summary}`);
+
+process.exit(toReport.length > 0 ? 1 : 0);

--- a/scripts/bin/validate-geometry.ts
+++ b/scripts/bin/validate-geometry.ts
@@ -1,24 +1,24 @@
-import { fileURLToPath } from "url";
-import { readFileSync, writeFileSync } from "fs";
-import { join, relative, resolve } from "path";
-import { parseArgs } from "node:util";
-import type { Feature, MultiPolygon, Polygon } from "geojson";
-import { findJsonFiles } from "./lib/traverse.ts";
+import {fileURLToPath} from 'url';
+import {readFileSync, writeFileSync} from 'fs';
+import {join, relative, resolve} from 'path';
+import {parseArgs} from 'node:util';
+import type {Feature, MultiPolygon, Polygon} from 'geojson';
+import {findJsonFiles} from './lib/traverse.ts';
 import {
   type Violation,
   applyFixes,
   findDuplicatePrefixSuffix,
   runFileChecks,
-} from "./lib/geometry-checks.ts";
+} from './lib/geometry-checks.ts';
 
 //  CLI
 
-const { values, positionals } = parseArgs({
+const {values, positionals} = parseArgs({
   args: process.argv.slice(2),
   options: {
-    "changed-only": { type: "boolean" },
-    fix: { type: "boolean" },
-    help: { type: "boolean", short: "h" },
+    'changed-only': {type: 'boolean'},
+    fix: {type: 'boolean'},
+    help: {type: 'boolean', short: 'h'},
   },
   allowPositionals: true,
 });
@@ -40,28 +40,28 @@ Exits non-zero on any violation.`);
 }
 
 const fix = !!values.fix;
-const changedOnly = !!values["changed-only"];
+const changedOnly = !!values['changed-only'];
 
 if (fix && changedOnly) {
-  console.error("--fix and --changed-only are mutually exclusive");
+  console.error('--fix and --changed-only are mutually exclusive');
   process.exit(2);
 }
 
 //  Path discovery
 
 const scriptPath = fileURLToPath(new URL(import.meta.url).toString());
-const rootPath = join(scriptPath, "../../../");
-const boundariesDir = join(rootPath, "Boundaries");
+const rootPath = join(scriptPath, '../../../');
+const boundariesDir = join(rootPath, 'Boundaries');
 
 const allFiles = findJsonFiles(boundariesDir);
 
 function relSlash(file: string): string {
-  return relative(rootPath, file).replace(/\\/g, "/");
+  return relative(rootPath, file).replace(/\\/g, '/');
 }
 
 function resolveBoundaryPath(input: string): string | null {
   const abs = resolve(rootPath, input);
-  return allFiles.find((f) => resolve(f) === abs) ?? null;
+  return allFiles.find(f => resolve(f) === abs) ?? null;
 }
 
 let changedSet: Set<string> | null = null;
@@ -70,20 +70,18 @@ if (changedOnly) {
   if (positionals.length > 0) {
     inputs.push(...positionals);
   } else if (!process.stdin.isTTY) {
-    const stdin = readFileSync(0, "utf8");
+    const stdin = readFileSync(0, 'utf8');
     inputs.push(
       ...stdin
         .split(/\r?\n/)
-        .map((s) => s.trim())
+        .map(s => s.trim())
         .filter(Boolean),
     );
   }
-  const resolved = inputs
-    .map(resolveBoundaryPath)
-    .filter((p): p is string => p !== null);
+  const resolved = inputs.map(resolveBoundaryPath).filter((p): p is string => p !== null);
   changedSet = new Set(resolved);
   if (changedSet.size === 0) {
-    console.log("No boundary files in changed set; nothing to validate.");
+    console.log('No boundary files in changed set; nothing to validate.');
     process.exit(0);
   }
 }
@@ -94,15 +92,15 @@ const violations: Violation[] = [];
 const featuresByFile = new Map<string, Feature<Polygon | MultiPolygon>>();
 
 for (const filePath of allFiles) {
-  const raw = readFileSync(filePath, "utf8");
+  const raw = readFileSync(filePath, 'utf8');
   let feature: Feature<Polygon | MultiPolygon>;
   try {
     feature = JSON.parse(raw);
   } catch (e) {
     violations.push({
       file: filePath,
-      rule: "json-parse",
-      severity: "error",
+      rule: 'json-parse',
+      severity: 'error',
       message: `Invalid JSON: ${(e as Error).message}`,
     });
     continue;
@@ -122,7 +120,7 @@ for (const filePath of allFiles) {
 }
 
 if (fix) {
-  console.log("Done. Re-run validate-geometry to confirm.");
+  console.log('Done. Re-run validate-geometry to confirm.');
   process.exit(0);
 }
 
@@ -132,9 +130,9 @@ violations.push(...findDuplicatePrefixSuffix(featuresByFile));
 
 let toReport = violations;
 if (changedSet) {
-  toReport = violations.filter((v) => {
+  toReport = violations.filter(v => {
     if (v.relatedFiles && v.relatedFiles.length > 0) {
-      return v.relatedFiles.some((f) => changedSet!.has(f));
+      return v.relatedFiles.some(f => changedSet!.has(f));
     }
     return changedSet!.has(v.file);
   });
@@ -144,8 +142,8 @@ if (changedSet) {
 
 for (const v of toReport) {
   const extra = v.relatedFiles
-    ? ` (involves: ${v.relatedFiles.map((f) => relSlash(f)).join(", ")})`
-    : "";
+    ? ` (involves: ${v.relatedFiles.map(f => relSlash(f)).join(', ')})`
+    : '';
   console.error(`ERROR  ${relSlash(v.file)} [${v.rule}] ${v.message}${extra}`);
 }
 

--- a/scripts/bin/validate-schema.ts
+++ b/scripts/bin/validate-schema.ts
@@ -1,22 +1,20 @@
-import { fileURLToPath } from "url";
-import { readFileSync } from "fs";
-import { join } from "path";
-import Ajv from "ajv/dist/2020.js";
-import { findJsonFiles } from "./lib/traverse.ts";
+import {fileURLToPath} from 'url';
+import {readFileSync} from 'fs';
+import {join} from 'path';
+import Ajv from 'ajv/dist/2020.js';
+import {findJsonFiles} from './lib/traverse.ts';
 
 const path = fileURLToPath(new URL(import.meta.url).toString());
-const schema = JSON.parse(
-  readFileSync(join(path, "../../../schema-single.json"), "utf-8"),
-);
-const rootPath = join(path, "../../../");
+const schema = JSON.parse(readFileSync(join(path, '../../../schema-single.json'), 'utf-8'));
+const rootPath = join(path, '../../../');
 
 const ajv = new Ajv();
 const validate = ajv.compile(schema);
 
-const files = findJsonFiles(join(rootPath, "Boundaries"));
+const files = findJsonFiles(join(rootPath, 'Boundaries'));
 
 files.forEach(function (value) {
-  const data = readFileSync(value, "utf8");
+  const data = readFileSync(value, 'utf8');
   const valid = validate(JSON.parse(data));
   if (!valid) {
     console.log(value);
@@ -24,4 +22,4 @@ files.forEach(function (value) {
   }
 });
 
-console.info("Schema is valid");
+console.info('Schema is valid');

--- a/scripts/bin/validate-schema.ts
+++ b/scripts/bin/validate-schema.ts
@@ -1,43 +1,27 @@
-import {fileURLToPath} from 'url';
-import {readFileSync} from 'fs';
-import {join} from 'path';
+import { fileURLToPath } from "url";
+import { readFileSync } from "fs";
+import { join } from "path";
 import Ajv from "ajv/dist/2020.js";
-import {lstatSync, readdirSync} from "node:fs";
-import {dirname, extname} from "node:path";
+import { findJsonFiles } from "./lib/traverse.ts";
 
 const path = fileURLToPath(new URL(import.meta.url).toString());
-const schema = JSON.parse(readFileSync(join(path, '../../../schema-single.json'), 'utf-8'))
-const rootPath = join(path, '../../../')
+const schema = JSON.parse(
+  readFileSync(join(path, "../../../schema-single.json"), "utf-8"),
+);
+const rootPath = join(path, "../../../");
 
-const ajv = new Ajv()
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
 
-const validate = ajv.compile(schema)
+const files = findJsonFiles(join(rootPath, "Boundaries"));
 
-const files: string[] = [];
+files.forEach(function (value) {
+  const data = readFileSync(value, "utf8");
+  const valid = validate(JSON.parse(data));
+  if (!valid) {
+    console.log(value);
+    throw validate.errors;
+  }
+});
 
-function traverseDir(dir: string) {
-    readdirSync(dir).forEach(file => {
-        let fullPath = join(dir, file);
-        if (lstatSync(fullPath).isDirectory()) {
-            traverseDir(fullPath);
-        } else {
-            if (!dirname(fullPath).toLowerCase().includes("node_modules") &&
-                extname(fullPath).toLowerCase() === ".json") {
-                files.push(fullPath);
-            }
-        }
-    })
-}
-
-traverseDir(join(rootPath, "Boundaries"));
-
-files.map(function (value) {
-    const data = readFileSync(value, 'utf8');
-    const valid = validate(JSON.parse(data))
-    if (!valid) {
-        console.log(value);
-        throw validate.errors;
-    }
-})
-
-console.info('Schema is valid');
+console.info("Schema is valid");

--- a/scripts/eslint.config.js
+++ b/scripts/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['node_modules/', '.yarn/', '**/*.geojson', '**/*.json'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['bin/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {argsIgnorePattern: '^_', varsIgnorePattern: '^_'},
+      ],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'prefer-const': 'error',
+      'no-console': 'off',
+    },
+  },
+];

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,10 +7,13 @@
   "scripts": {
     "compile": "node --experimental-strip-types bin/compile.ts",
     "validate-schema": "node --experimental-strip-types bin/validate-schema.ts",
-    "check-contributor": "node --experimental-strip-types bin/contributor.ts"
+    "validate-geometry": "node --experimental-strip-types bin/validate-geometry.ts",
+    "validate": "yarn validate-schema && yarn validate-geometry",
+    "check-contributor": "node --experimental-strip-types bin/contributor.ts",
+    "ownership-report": "node --experimental-strip-types bin/ownership-report.ts"
   },
   "dependencies": {
-    "ajv": "^8.17.1",
+    "ajv": "8.18.0",
     "csv-parse": "^6.1.0",
     "csv-parser": "^3.2.0",
     "fast-csv": "^5.0.5"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,10 @@
     "validate-geometry": "node --experimental-strip-types bin/validate-geometry.ts",
     "validate": "yarn validate-schema && yarn validate-geometry",
     "check-contributor": "node --experimental-strip-types bin/contributor.ts",
-    "ownership-report": "node --experimental-strip-types bin/ownership-report.ts"
+    "ownership-report": "node --experimental-strip-types bin/ownership-report.ts",
+    "lint": "eslint bin",
+    "format": "prettier --write \"bin/**/*.ts\"",
+    "format:check": "prettier --check \"bin/**/*.ts\""
   },
   "dependencies": {
     "ajv": "8.18.0",
@@ -19,11 +22,16 @@
     "fast-csv": "^5.0.5"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
     "@types/geojson": "^7946.0.16",
     "@types/node": "^25.0.9",
+    "eslint": "^9.17.0",
     "geojson": "^0.5.0",
+    "globals": "^15.14.0",
+    "prettier": "^3.4.2",
     "tsc": "^2.0.4",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.20.0"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -5,6 +5,94 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/dc4ab5e3e364ef27e33666b11f4b86e1a6c1d7cbf16f0c6ff87b1619b3562335e9201a3d6ce806221887ff780ec9d828962a290bb910759fd40a674686503f02
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2":
+  version: 4.12.2
+  resolution: "@eslint-community/regexpp@npm:4.12.2"
+  checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
+  languageName: node
+  linkType: hard
+
+"@eslint/config-array@npm:^0.21.2":
+  version: 0.21.2
+  resolution: "@eslint/config-array@npm:0.21.2"
+  dependencies:
+    "@eslint/object-schema": "npm:^2.1.7"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^3.1.5"
+  checksum: 10c0/89dfe815d18456177c0a1f238daf4593107fd20298b3598e0103054360d3b8d09d967defd8318f031185d68df1f95cfa68becf1390a9c5c6887665f1475142e3
+  languageName: node
+  linkType: hard
+
+"@eslint/config-helpers@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@eslint/config-helpers@npm:0.4.2"
+  dependencies:
+    "@eslint/core": "npm:^0.17.0"
+  checksum: 10c0/92efd7a527b2d17eb1a148409d71d80f9ac160b565ac73ee092252e8bf08ecd08670699f46b306b94f13d22e88ac88a612120e7847570dd7cdc72f234d50dcb4
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@eslint/core@npm:0.17.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/9a580f2246633bc752298e7440dd942ec421860d1946d0801f0423830e67887e4aeba10ab9a23d281727a978eb93d053d1922a587d502942a713607f40ed704e
+  languageName: node
+  linkType: hard
+
+"@eslint/eslintrc@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@eslint/eslintrc@npm:3.3.5"
+  dependencies:
+    ajv: "npm:^6.14.0"
+    debug: "npm:^4.3.2"
+    espree: "npm:^10.0.1"
+    globals: "npm:^14.0.0"
+    ignore: "npm:^5.2.0"
+    import-fresh: "npm:^3.2.1"
+    js-yaml: "npm:^4.1.1"
+    minimatch: "npm:^3.1.5"
+    strip-json-comments: "npm:^3.1.1"
+  checksum: 10c0/9fb9f1ca65e46d6173966e3aaa5bd353e3a65d7f1f582bebf77f578fab7d7960a399fac1ecfb1e7d52bd61f5cefd6531087ca52a3a3c388f2e1b4f1ebd3da8b7
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:9.39.4, @eslint/js@npm:^9.17.0":
+  version: 9.39.4
+  resolution: "@eslint/js@npm:9.39.4"
+  checksum: 10c0/5aa7dea2cbc5decf7f5e3b0c6f86a084ccee0f792d288ca8e839f8bc1b64e03e227068968e49b26096e6f71fd857ab6e42691d1b993826b9a3883f1bdd7a0e46
+  languageName: node
+  linkType: hard
+
+"@eslint/object-schema@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "@eslint/object-schema@npm:2.1.7"
+  checksum: 10c0/936b6e499853d1335803f556d526c86f5fe2259ed241bc665000e1d6353828edd913feed43120d150adb75570cae162cf000b5b0dfc9596726761c36b82f4e87
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@eslint/plugin-kit@npm:0.4.1"
+  dependencies:
+    "@eslint/core": "npm:^0.17.0"
+    levn: "npm:^0.4.1"
+  checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
+  languageName: node
+  linkType: hard
+
 "@fast-csv/format@npm:5.0.5":
   version: 5.0.5
   resolution: "@fast-csv/format@npm:5.0.5"
@@ -31,10 +119,65 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanfs/core@npm:^0.19.2":
+  version: 0.19.2
+  resolution: "@humanfs/core@npm:0.19.2"
+  dependencies:
+    "@humanfs/types": "npm:^0.15.0"
+  checksum: 10c0/d0a1d52d7b30c27d49475a53072d1510b81c5803e44b342fb8faf3887f1aa27593a1e6dc76a45268e7892d3f4e198146659281f6b6d55eacf3fd5a38bac30c5c
+  languageName: node
+  linkType: hard
+
+"@humanfs/node@npm:^0.16.6":
+  version: 0.16.8
+  resolution: "@humanfs/node@npm:0.16.8"
+  dependencies:
+    "@humanfs/core": "npm:^0.19.2"
+    "@humanfs/types": "npm:^0.15.0"
+    "@humanwhocodes/retry": "npm:^0.4.0"
+  checksum: 10c0/56140579db811af4e160b195d45d0f29acf644d192c93fe24c9e594ebf06f19dfc157494a07c84540b8a071c0e4b37209c2362765d31734f4d0be869c2422e25
+  languageName: node
+  linkType: hard
+
+"@humanfs/types@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@humanfs/types@npm:0.15.0"
+  checksum: 10c0/fc26b9a024b0e55f7eaf64036df94345bf5d36d6a41ef80ef38e78f1f7430ce26cf435af736adae58913baae18eac3f38c18739054a3d379102015978eae862e
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/module-importer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@humanwhocodes/module-importer@npm:1.0.1"
+  checksum: 10c0/909b69c3b86d482c26b3359db16e46a32e0fb30bd306a3c176b8313b9e7313dba0f37f519de6aa8b0a1921349e505f259d19475e123182416a506d7f87e7f529
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.4.0, @humanwhocodes/retry@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "@humanwhocodes/retry@npm:0.4.3"
+  checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.6":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+  languageName: node
+  linkType: hard
+
 "@types/geojson@npm:^7946.0.16":
   version: 7946.0.16
   resolution: "@types/geojson@npm:7946.0.16"
   checksum: 10c0/1ff24a288bd5860b766b073ead337d31d73bdc715e5b50a2cee5cb0af57a1ed02cc04ef295f5fa68dc40fe3e4f104dd31282b2b818a5ba3231bc1001ba084e3c
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
   languageName: node
   linkType: hard
 
@@ -47,6 +190,159 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.1"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.1"
+    "@typescript-eslint/type-utils": "npm:8.59.1"
+    "@typescript-eslint/utils": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    ignore: "npm:^7.0.5"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.59.1
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/6dedd272d1aac960df74ab81e38bb4b398ac11b52118c69493a3aeecd15984c83bd4cae89df2e8362fbc2213f0a6d68c00d71dd53868fa1b5e1011290d4ea7b6
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/parser@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/a20271b96e35fa5a8deea11ec40b30f7987daa5c3402e6e763e474517a25af20749a620490af159c2a65048065dea8a6d5fa3527ccc7a3716c2cd648a05ebc55
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/project-service@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/project-service@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.1"
+    "@typescript-eslint/types": "npm:^8.59.1"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/487e60e9696fbae11070fd0591a009c94b932af2a92d37a1a9d9f9eac5bbc2f56fef83f3d4e72349dfdaadf95473bb5fb7332eb13f9296b87b3f14e842f42747
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+  checksum: 10c0/05c19039bde67691ad7a558ac61260639593ab0ffd8b73903b0f23c770aa3d79868bc8c1a11cdd5b0c8226e5dcef9ab1d679db46b5c5fe019541216170451614
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.59.1, @typescript-eslint/tsconfig-utils@npm:^8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/a3d123edbc39e7bfa3f58f722fe755787e71771d97b03ed80ea0706dcf3f25895e217e61b38049db1b05f246a26c6afb4e4a518bad21e7d1e71bb8dc136084ce
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/type-utils@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+    "@typescript-eslint/utils": "npm:8.59.1"
+    debug: "npm:^4.4.3"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/c5f0f8e53f85ddf796a45b485937b7d5aef5c884fed412ff945392376166242658e4b431bd9633e1e08d6dba7e83b6125283e4866f5a9b4ae61fec355705122d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.59.1, @typescript-eslint/types@npm:^8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/types@npm:8.59.1"
+  checksum: 10c0/a0bf98389e8673d4aa1034fdef9bb78f576b3dc6b8f413d4adf07ef6edff4a33fdb916148c3bac2cafdbf282c765eebf253c2a05edf3fda4123b8889921cd518
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.59.1"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/80b2624185d303741a710ba90e4fcb4e52320c1fc614f62cce785bfb39dfb9560ea5d325ff590d929c689b7dae7c28a598a26e1862477cc108c4ae4e8fe62c78
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/utils@npm:8.59.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/82a3fdb52d5f54622f8796eaeca508c630e65bfb94423645c1097b377fd56cf43b2999a83f11f42924e0cbb93b22faca6e572ee27cf550795b99e22193a0d41c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.1"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/1144426dda53e855698301eae6301ae928785915225e6a775f0b51bf5d67b67e90def7b851e851ce76235cff3e1324132d03c7843a33ce2c4f0eb0764cc2b80a
+  languageName: node
+  linkType: hard
+
+"acorn-jsx@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "acorn-jsx@npm:5.3.2"
+  peerDependencies:
+    acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/4c54868fbef3b8d58927d5e33f0a4de35f59012fe7b12cf9dfbb345fb8f46607709e1c4431be869a23fb63c151033d84c4198fa9f79385cec34fcb1dd53974c1
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.15.0":
+  version: 8.16.0
+  resolution: "acorn@npm:8.16.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
+  languageName: node
+  linkType: hard
+
 "ajv@npm:8.18.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
@@ -56,6 +352,118 @@ __metadata:
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
   checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.14.0":
+  version: 6.15.0
+  resolution: "ajv@npm:6.15.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
+  checksum: 10c0/67966499dd272ecde1c2e467084411132891523d057487587879d39ac04207f4351b7b2324c83198013967fbfa632c1612adc960114a30770fbe07a0773b32c2
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.1.0":
+  version: 4.3.0
+  resolution: "ansi-styles@npm:4.3.0"
+  dependencies:
+    color-convert: "npm:^2.0.1"
+  checksum: 10c0/895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
+  languageName: node
+  linkType: hard
+
+"balanced-match@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^1.1.7":
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  languageName: node
+  linkType: hard
+
+"callsites@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "callsites@npm:3.1.0"
+  checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.0.0":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
+"color-convert@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "color-convert@npm:2.0.1"
+  dependencies:
+    color-name: "npm:~1.1.4"
+  checksum: 10c0/37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
+  languageName: node
+  linkType: hard
+
+"color-name@npm:~1.1.4":
+  version: 1.1.4
+  resolution: "color-name@npm:1.1.4"
+  checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"concat-map@npm:0.0.1":
+  version: 0.0.1
+  resolution: "concat-map@npm:0.0.1"
+  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
   languageName: node
   linkType: hard
 
@@ -75,6 +483,155 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
+"deep-is@npm:^0.1.3":
+  version: 0.1.4
+  resolution: "deep-is@npm:0.1.4"
+  checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 10c0/9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "eslint-scope@npm:8.4.0"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 10c0/92708e882c0a5ffd88c23c0b404ac1628cf20104a108c745f240a13c332a11aac54f49a22d5762efbffc18ecbc9a580d1b7ad034bf5f3cc3307e5cbff2ec9820
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-visitor-keys@npm:4.2.1"
+  checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "eslint-visitor-keys@npm:5.0.1"
+  checksum: 10c0/16190bdf2cbae40a1109384c94450c526a79b0b9c3cb21e544256ed85ac48a4b84db66b74a6561d20fe6ab77447f150d711c2ad5ad74df4fcc133736bce99678
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^9.17.0":
+  version: 9.39.4
+  resolution: "eslint@npm:9.39.4"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.8.0"
+    "@eslint-community/regexpp": "npm:^4.12.1"
+    "@eslint/config-array": "npm:^0.21.2"
+    "@eslint/config-helpers": "npm:^0.4.2"
+    "@eslint/core": "npm:^0.17.0"
+    "@eslint/eslintrc": "npm:^3.3.5"
+    "@eslint/js": "npm:9.39.4"
+    "@eslint/plugin-kit": "npm:^0.4.1"
+    "@humanfs/node": "npm:^0.16.6"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.4.2"
+    "@types/estree": "npm:^1.0.6"
+    ajv: "npm:^6.14.0"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^8.4.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+    espree: "npm:^10.4.0"
+    esquery: "npm:^1.5.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.1.5"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/1955067c2d991f0c84f4c4abfafe31bb47fa3b717a7fd3e43fe1e511c6f859d7700cbca969f85661dc4c130f7aeced5e5444884314198a54428f5e5141db9337
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.0.1, espree@npm:^10.4.0":
+  version: 10.4.0
+  resolution: "espree@npm:10.4.0"
+  dependencies:
+    acorn: "npm:^8.15.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.5.0":
+  version: 1.7.0
+  resolution: "esquery@npm:1.7.0"
+  dependencies:
+    estraverse: "npm:^5.1.0"
+  checksum: 10c0/77d5173db450b66f3bc685d11af4c90cffeedb340f34a39af96d43509a335ce39c894fd79233df32d38f5e4e219fa0f7076f6ec90bae8320170ba082c0db4793
+  languageName: node
+  linkType: hard
+
+"esrecurse@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "esrecurse@npm:4.3.0"
+  dependencies:
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/81a37116d1408ded88ada45b9fb16dbd26fba3aadc369ce50fcaf82a0bac12772ebd7b24cd7b91fc66786bf2c1ac7b5f196bc990a473efff972f5cb338877cf5
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 10c0/1ff9447b96263dec95d6d67431c5e0771eb9776427421260a3e2f0fdd5d6bd4f8e37a7338f5ad2880c9f143450c9b1e4fc2069060724570a49cf9cf0312bd107
+  languageName: node
+  linkType: hard
+
+"esutils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "esutils@npm:2.0.3"
+  checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
+  languageName: node
+  linkType: hard
+
 "fast-csv@npm:^5.0.5":
   version: 5.0.5
   resolution: "fast-csv@npm:5.0.5"
@@ -85,10 +642,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
+"fast-json-stable-stringify@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
+  languageName: node
+  linkType: hard
+
+"fast-levenshtein@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "fast-levenshtein@npm:2.0.6"
+  checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
   languageName: node
   linkType: hard
 
@@ -99,6 +670,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "fdir@npm:6.5.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
+"file-entry-cache@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "file-entry-cache@npm:8.0.0"
+  dependencies:
+    flat-cache: "npm:^4.0.0"
+  checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: "npm:^6.0.0"
+    path-exists: "npm:^4.0.0"
+  checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "flat-cache@npm:4.0.1"
+  dependencies:
+    flatted: "npm:^3.2.9"
+    keyv: "npm:^4.5.4"
+  checksum: 10c0/2c59d93e9faa2523e4fda6b4ada749bed432cfa28c8e251f33b25795e426a1c6dbada777afb1f74fcfff33934fdbdea921ee738fcc33e71adc9d6eca984a1cfc
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.2.9":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
+  languageName: node
+  linkType: hard
+
 "geojson@npm:^0.5.0":
   version: 0.5.0
   resolution: "geojson@npm:0.5.0"
@@ -106,10 +725,154 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: "npm:^4.0.3"
+  checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
+  languageName: node
+  linkType: hard
+
+"globals@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "globals@npm:14.0.0"
+  checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
+  languageName: node
+  linkType: hard
+
+"globals@npm:^15.14.0":
+  version: 15.15.0
+  resolution: "globals@npm:15.15.0"
+  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "has-flag@npm:4.0.0"
+  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.2.0":
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
+  languageName: node
+  linkType: hard
+
+"import-fresh@npm:^3.2.1":
+  version: 3.3.1
+  resolution: "import-fresh@npm:3.3.1"
+  dependencies:
+    parent-module: "npm:^1.0.0"
+    resolve-from: "npm:^4.0.0"
+  checksum: 10c0/bf8cc494872fef783249709385ae883b447e3eb09db0ebd15dcead7d9afe7224dad7bd7591c6b73b0b19b3c0f9640eb8ee884f01cfaf2887ab995b0b36a0cbec
+  languageName: node
+  linkType: hard
+
+"imurmurhash@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "imurmurhash@npm:0.1.4"
+  checksum: 10c0/8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
+  languageName: node
+  linkType: hard
+
+"is-extglob@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "is-extglob@npm:2.1.1"
+  checksum: 10c0/5487da35691fbc339700bbb2730430b07777a3c21b9ebaecb3072512dfd7b4ba78ac2381a87e8d78d20ea08affb3f1971b4af629173a6bf435ff8a4c47747912
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "is-glob@npm:4.0.3"
+  dependencies:
+    is-extglob: "npm:^2.1.1"
+  checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"isexe@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "isexe@npm:2.0.0"
+  checksum: 10c0/228cfa503fadc2c31596ab06ed6aa82c9976eec2bfd83397e7eaf06d0ccf42cd1dfd6743bf9aeb01aebd4156d009994c5f76ea898d2832c1fe342da923ca457d
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  languageName: node
+  linkType: hard
+
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 10c0/0d1c91569d9588e7eef2b49b59851f297f3ab93c7b35c7c221e288099322be6b562767d11e4821da500f3219542b9afd2e54c5dc573107c1126ed1080f8e96d7
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "json-schema-traverse@npm:0.4.1"
+  checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^1.0.0":
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-stable-stringify-without-jsonify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
+  checksum: 10c0/cb168b61fd4de83e58d09aaa6425ef71001bae30d260e2c57e7d09a5fd82223e2f22a042dedaab8db23b7d9ae46854b08bb1f91675a8be11c5cffebef5fb66a5
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "keyv@npm:4.5.4"
+  dependencies:
+    json-buffer: "npm:3.0.1"
+  checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"levn@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "levn@npm:0.4.1"
+  dependencies:
+    prelude-ls: "npm:^1.2.1"
+    type-check: "npm:~0.4.0"
+  checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "locate-path@npm:6.0.0"
+  dependencies:
+    p-locate: "npm:^5.0.0"
+  checksum: 10c0/d3972ab70dfe58ce620e64265f90162d247e87159b6126b01314dd67be43d50e96a50b517bce2d9452a79409c7614054c277b5232377de50416564a77ac7aad3
   languageName: node
   linkType: hard
 
@@ -155,10 +918,134 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.merge@npm:^4.6.2":
+  version: 4.6.2
+  resolution: "lodash.merge@npm:4.6.2"
+  checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
+  languageName: node
+  linkType: hard
+
 "lodash.uniq@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.uniq@npm:4.5.0"
   checksum: 10c0/262d400bb0952f112162a320cc4a75dea4f66078b9e7e3075ffbc9c6aa30b3e9df3cf20e7da7d566105e1ccf7804e4fbd7d804eee0b53de05d83f16ffbf41c5e
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.2":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
+  languageName: node
+  linkType: hard
+
+"ms@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "ms@npm:2.1.3"
+  checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"natural-compare@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare@npm:1.4.0"
+  checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
+  languageName: node
+  linkType: hard
+
+"optionator@npm:^0.9.3":
+  version: 0.9.4
+  resolution: "optionator@npm:0.9.4"
+  dependencies:
+    deep-is: "npm:^0.1.3"
+    fast-levenshtein: "npm:^2.0.6"
+    levn: "npm:^0.4.1"
+    prelude-ls: "npm:^1.2.1"
+    type-check: "npm:^0.4.0"
+    word-wrap: "npm:^1.2.5"
+  checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: "npm:^0.1.0"
+  checksum: 10c0/9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "p-locate@npm:5.0.0"
+  dependencies:
+    p-limit: "npm:^3.0.2"
+  checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
+  languageName: node
+  linkType: hard
+
+"parent-module@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "parent-module@npm:1.0.1"
+  dependencies:
+    callsites: "npm:^3.0.0"
+  checksum: 10c0/c63d6e80000d4babd11978e0d3fee386ca7752a02b035fd2435960ffaa7219dc42146f07069fb65e6e8bf1caef89daf9af7535a39bddf354d78bf50d8294f556
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-exists@npm:4.0.0"
+  checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "path-key@npm:3.1.1"
+  checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
+"prelude-ls@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "prelude-ls@npm:1.2.1"
+  checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.4.2":
+  version: 3.8.3
+  resolution: "prettier@npm:3.8.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/754816fd7593eb80f6376d7476d463e832c38a12f32775a82683adb6e35b772b1f484d65f19401507b983a8c8a7cd5a4a9f12006bd56491e8f35503473f77473
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
   languageName: node
   linkType: hard
 
@@ -169,21 +1056,93 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-from@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "resolve-from@npm:4.0.0"
+  checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.3":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"shebang-command@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "shebang-command@npm:2.0.0"
+  dependencies:
+    shebang-regex: "npm:^3.0.0"
+  checksum: 10c0/a41692e7d89a553ef21d324a5cceb5f686d1f3c040759c50aab69688634688c5c327f26f3ecf7001ebfd78c01f3c7c0a11a7c8bfd0a8bc9f6240d4f40b224e4e
+  languageName: node
+  linkType: hard
+
+"shebang-regex@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "shebang-regex@npm:3.0.0"
+  checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
 "simaware-helpers@workspace:.":
   version: 0.0.0-use.local
   resolution: "simaware-helpers@workspace:."
   dependencies:
+    "@eslint/js": "npm:^9.17.0"
     "@types/geojson": "npm:^7946.0.16"
     "@types/node": "npm:^25.0.9"
     ajv: "npm:8.18.0"
     csv-parse: "npm:^6.1.0"
     csv-parser: "npm:^3.2.0"
+    eslint: "npm:^9.17.0"
     fast-csv: "npm:^5.0.5"
     geojson: "npm:^0.5.0"
+    globals: "npm:^15.14.0"
+    prettier: "npm:^3.4.2"
     tsc: "npm:^2.0.4"
     typescript: "npm:^5.9.3"
+    typescript-eslint: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
+
+"strip-json-comments@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "strip-json-comments@npm:3.1.1"
+  checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.15":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "ts-api-utils@npm:2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
+  languageName: node
+  linkType: hard
 
 "tsc@npm:^2.0.4":
   version: 2.0.4
@@ -191,6 +1150,30 @@ __metadata:
   bin:
     tsc: bin/tsc
   checksum: 10c0/4651d344891d995e62ab7ca64ce0a8597bbdc2d392886c9956d15caab4dc9bfe86e759d3385b3f97c49fb5294194a161d6812673e3f51e46357c82482f32c3ab
+  languageName: node
+  linkType: hard
+
+"type-check@npm:^0.4.0, type-check@npm:~0.4.0":
+  version: 0.4.0
+  resolution: "type-check@npm:0.4.0"
+  dependencies:
+    prelude-ls: "npm:^1.2.1"
+  checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.20.0":
+  version: 8.59.1
+  resolution: "typescript-eslint@npm:8.59.1"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.59.1"
+    "@typescript-eslint/parser": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+    "@typescript-eslint/utils": "npm:8.59.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/93f3d66e2a2427a719a19f7bfd5d21c76a6bdcf9cfe82ba14d37f869434893f7d4d62c75671a87a93a3ef13816636d2bfe79b2f145d6cbcda5efbfddd90c1c2d
   languageName: node
   linkType: hard
 
@@ -218,5 +1201,39 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+  languageName: node
+  linkType: hard
+
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"which@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "which@npm:2.0.2"
+  dependencies:
+    isexe: "npm:^2.0.0"
+  bin:
+    node-which: ./bin/node-which
+  checksum: 10c0/66522872a768b60c2a65a57e8ad184e5372f5b6a9ca6d5f033d4b0dc98aff63995655a7503b9c0a2598936f532120e81dd8cc155e2e92ed662a2b9377cc4374f
+  languageName: node
+  linkType: hard
+
+"word-wrap@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "word-wrap@npm:1.2.5"
+  checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -47,15 +47,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.17.1":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
+"ajv@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
+  checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
   languageName: node
   linkType: hard
 
@@ -175,7 +175,7 @@ __metadata:
   dependencies:
     "@types/geojson": "npm:^7946.0.16"
     "@types/node": "npm:^25.0.9"
-    ajv: "npm:^8.17.1"
+    ajv: "npm:8.18.0"
     csv-parse: "npm:^6.1.0"
     csv-parser: "npm:^3.2.0"
     fast-csv: "npm:^5.0.5"


### PR DESCRIPTION
This PR introduces various changes to ensure the ongoing quality of the dataset. 

## Schema and geometry validation

- `schema-single.json` now requires polygon rings to have at least 4 positions (3 unique vertices + closure).
- New `scripts/bin/validate-geometry.ts` enforces three rule categories beyond the schema: ring closure, coordinate precision (max 7 decimal places), and dataset-wide uniqueness of prefix/suffix pairs.
- `--fix` flag auto-rounds coordinates and closes open rings in place, so contributors aren't doing this by hand.
- `--changed-only` mode lets PR validation grandfather existing violations on main while still blocking new ones. This allows us to gradually fix existing violations.

## New tooling

- `ownership-report.ts` generates a markdown report mapping geometry violations back to git authors, filtering out bulk-edit operations, and matching with approved contributors. Useful for targeted cleanup outreach.
- `traverse.ts` is a shared recursive walker for .json discovery, used by both validators.
- `compile.ts` and `contributor.ts` reformatted to the new lint/prettier rules; no behavioural change.

## CI

- PR workflow (`check.yml`) now runs: changed-files geometry validation, dataset-wide prefix/suffix conflict check, contributor allowlist check, and lint/format checks on /scripts/.
- Push-to-main workflow (`push.yml`) runs a non-blocking full-dataset geometry sweep and uploads a geometry-report.txt artifact. This acts as an ongoing measure of data quality without breaking future merges.

## Code quality

- ESLint + Prettier added for all scripts within `/scripts/`.

## Documentation

- New `CONTRIBUTING.md` consolidates: approved-contributor process, PR submission checklist, geometry standards (with cross-refs to --fix), and the local validation workflow.
- `README.md` slimmed down - contributor process moved out into `CONTRIBUTING`.
- PR template updated to reference `CONTRIBUTING.md` and the new validation steps.