### PR TITLE
[LIXX] Fix overlapping labels

### DIFF
--- a/Boundaries/LIMJ/LIMJ.json
+++ b/Boundaries/LIMJ/LIMJ.json
@@ -3,7 +3,9 @@
   "properties": {
     "id": "WS0",
     "prefix": ["LIMJ"],
-    "name": "Milano Radar"
+    "name": "Milano Radar",
+    "label_lat": 43.915555555556,
+    "label_lon": 9.465
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/Boundaries/LIMM/ANW.json
+++ b/Boundaries/LIMM/ANW.json
@@ -5,7 +5,9 @@
     "prefix": [
       "LIMM_ANW"
     ],
-    "name": "Milano Radar"
+    "name": "Milano Radar",
+	"label_lat": 45.596297222222,
+	"label_lon": 7.9621805555556
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/Boundaries/LIMM/LAR.json
+++ b/Boundaries/LIMM/LAR.json
@@ -5,7 +5,9 @@
     "prefix": [
       "LIMM_LA"
     ],
-    "name": "Milano Radar"
+    "name": "Milano Radar",
+	"label_lat": 44.733541666667,
+	"label_lon": 10.014658333333
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/Boundaries/LIMM/MAR.json
+++ b/Boundaries/LIMM/MAR.json
@@ -5,7 +5,9 @@
     "prefix": [
       "LIMM_MA"
     ],
-    "name": "Milano Radar"
+    "name": "Milano Radar",
+	"label_lat": 45.0475,
+	"label_lon": 8.62
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/Boundaries/LIMM/WW0.json
+++ b/Boundaries/LIMM/WW0.json
@@ -3,7 +3,9 @@
   "properties": {
     "id": "WW0",
     "prefix": ["LIMM_WW"],
-    "name": "Milano Radar"
+    "name": "Milano Radar",
+    "label_lat": 44.614444444444,
+    "label_lon": 8.6475
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/Boundaries/LIPZ/SC0.json
+++ b/Boundaries/LIPZ/SC0.json
@@ -5,7 +5,9 @@
     "prefix": [
       "LIPP"
     ],
-    "name": "Padova Radar"
+    "name": "Padova Radar",
+	"label_lat": 45.579166666667,
+	"label_lon": 12.677222222222
   },
   "geometry": {
     "type": "MultiPolygon",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added label coordinates to multiple sectors to avoid label overlapping on sectors with different splits

## Is this a breaking change?
<!--- Does the change require the user to change something on their side? -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- To be on the approved list of contributors, read the README.md -->

- [x] My change or addition follow the formatting standard of the project.
- [x] I am on the list of approved contributors. 

<!-- markdownlint-disable-file MD041 -->
